### PR TITLE
Parse scores and exon-frames in refGene.txt

### DIFF
--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -49,10 +49,12 @@
         (update m :exon-count as-long)
         (update m :exon-start #(map inc (parse-exon-pos %)))
         (update m :exon-end parse-exon-pos)
+        (update m :score as-long)
         (assoc m :exon-ranges (exon-ranges (:exon-start m) (:exon-end m)))
         (dissoc m :exon-start :exon-end)
         (update m :cds-start-stat keyword)
-        (update m :cds-end-stat keyword)))
+        (update m :cds-end-stat keyword)
+        (update m :exon-frames parse-exon-pos)))
 
 (defn load-ref-genes
   "Loads f (e.g. refGene.txt(.gz)), returning the all contents as a sequence."

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -18,11 +18,11 @@
           :cds-end 981029
           :exon-count 4
           :exon-ranges [[975199 976269] [976499 976624] [978881 981047] [982065 982117]]
-          :score "0"
+          :score 0
           :name2 "PERM1"
           :cds-start-stat :cmpl
           :cds-end-stat :cmpl
-          :exon-frames "1,1,0,-1,"})))
+          :exon-frames '(1 1 0 -1)})))
 
 (defslowtest in-any-exon?-test
   (cavia-testing "in-any-exon? (slow)"


### PR DESCRIPTION
I think it's better to parse `score` and `exon-frames` in refGene.txt.
If you're intentionally leaving these fields unparsed for performance reason or something, please ignore this PR.

Thank you.