### PR TITLE
Add function to retrieve exon regions

### DIFF
--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -134,6 +134,21 @@
        (some #(in-exon? pos %))
        (true?)))
 
+(defn seek-exon
+  "Seeks chr:pos through exon entries in refGene and returns those indices"
+  [chr pos rgidx]
+  (->> (ref-genes chr pos rgidx)
+       (map (fn [rg]
+              (let [exon-ranges ((case (:strand rg)
+                                    "+" identity
+                                    "-" reverse) (:exon-ranges rg))]
+                {:exon-index (->> exon-ranges
+                                  (keep-indexed (fn [i [s e]] (if (<= s pos e) i)))
+                                  first
+                                  inc) ; 1-origin
+                 :exon-count (count exon-ranges)
+                 :gene rg})))))
+
 ;;; Calculation of CDS coordinate
 ;;;
 ;;; cf. http://varnomen.hgvs.org/bg-material/numbering/

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -134,20 +134,28 @@
        (some #(in-exon? pos %))
        (true?)))
 
-(defn seek-exon
+(defn seek-gene-region
   "Seeks chr:pos through exon entries in refGene and returns those indices"
-  [chr pos rgidx]
-  (->> (ref-genes chr pos rgidx)
-       (map (fn [rg]
-              (let [exon-ranges ((case (:strand rg)
+  ([chr pos rgidx]
+   (seek-gene-region chr pos rgidx nil))
+  ([chr pos rgidx name]
+   ;; TODO seek intron region
+   ;; TODO seek UTR-5 or UTR-3 region
+   (->> (if name
+          (ref-genes name rgidx)
+          (ref-genes chr pos rgidx))
+        (map (fn [rg]
+               (let [exon-ranges ((case (:strand rg)
                                     "+" identity
-                                    "-" reverse) (:exon-ranges rg))]
-                {:exon-index (->> exon-ranges
-                                  (keep-indexed (fn [i [s e]] (if (<= s pos e) i)))
-                                  first
-                                  inc) ; 1-origin
-                 :exon-count (count exon-ranges)
-                 :gene rg})))))
+                                    "-" reverse) (:exon-ranges rg))
+                     idx (->> exon-ranges
+                              (keep-indexed (fn [i [s e]] (if (<= s pos e) i)))
+                              first)]
+                 {:exon-index (if idx
+                                (inc idx) ; 1-origin
+                                nil)
+                  :exon-count (count exon-ranges)
+                  :gene rg}))))))
 
 ;;; Calculation of CDS coordinate
 ;;;

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -30,6 +30,17 @@
       (is (true? (rg/in-any-exon? "chr7" 55191822 rgidx)))
       (is (false? (rg/in-any-exon? "chr7" 55019367 rgidx))))))
 
+(defslowtest seek-exon-test
+  (cavia-testing "seek-exon (slow)"
+    (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
+      (are [c p tn exs] (= exs
+                           (->> (rg/seek-gene-region c p rgidx tn)
+                                (map #(vector (:exon-index %) (:exon-count %)))))
+        "chr4" 54736520   nil        [[18 21] [18 21]]
+        "chr7" 116771976 "NM_000245" [[14 21]]
+        "chrX" 61197987   nil        []
+        "chr3" 41217131  "NM_001904" [[nil 15]]))))
+
 (deftest cds-coord-test
   ;; 1 [2 3 4] 5 6 7 [8 9 10 11] 12 13 14 15
   (testing "strand +"

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -30,8 +30,8 @@
       (is (true? (rg/in-any-exon? "chr7" 55191822 rgidx)))
       (is (false? (rg/in-any-exon? "chr7" 55019367 rgidx))))))
 
-(defslowtest seek-exon-test
-  (cavia-testing "seek-exon (slow)"
+(defslowtest seek-gene-region-test
+  (cavia-testing "seek-gene-region (slow)"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [c p tn exs] (= exs
                            (->> (rg/seek-gene-region c p rgidx tn)


### PR DESCRIPTION
I have added the function to retrieve exon regions for a specified genomic position.

I think it is better to additionally support to retrieve intronic/UTR region information.
So I added TODO comment as the remaining tasks.

Thanks.
