### PR TITLE
Fix mistranslation from HGVS to vcf variant

### DIFF
--- a/src/varity/hgvs_to_vcf/protein.clj
+++ b/src/varity/hgvs_to_vcf/protein.clj
@@ -61,7 +61,8 @@
                               (apply str))
               ref-codon (cond-> ref-codon1 (= strand "-") revcomp-bases)
               palt (mut/->short-amino-acid (:alt mut*))
-              codon-cands (codon/amino-acid->codons palt)]
+              codon-cands (codon/amino-acid->codons palt)
+              pos-cands (cond-> pos-cands (= strand "-") reverse)]
           (->> codon-cands
                (keep (fn [codon*]
                       (->> pos-cands

--- a/src/varity/hgvs_to_vcf/protein.clj
+++ b/src/varity/hgvs_to_vcf/protein.clj
@@ -74,10 +74,10 @@
                                         :pos pos
                                         :ref (cond-> ref (= strand "-") revcomp-bases)
                                         :alt (cond-> alt (= strand "-") revcomp-bases)}
-                                  :cdna (hgvs/hgvs nil :cdna (mut/dna-substitution (rg/cds-coord pos rg)
-                                                                                   ref
-                                                                                   (if (= ref alt) "=" ">")
-                                                                                   alt))}))))
+                                  :cdna (hgvs/hgvs (:name rg) :cdna (mut/dna-substitution (rg/cds-coord pos rg)
+                                                                                  ref
+                                                                                  (if (= ref alt) "=" ">")
+                                                                                  alt))}))))
                            (remove nil?))))
                (flatten)))))
     (throw (IllegalArgumentException. "Unsupported mutation"))))

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -82,4 +82,12 @@
           (= (hgvs->vcf-variants (hgvs/parse hgvs*) gene test-ref-seq-file rgidx) e)
         "p.L858R" "EGFR" '({:chr "chr7", :pos 55191822, :ref "T", :alt "G"}) ; cf. rs121434568
         "p.A222V" "MTHFR" '({:chr "chr1", :pos 11796321, :ref "G", :alt "A"}) ; cf. rs1801133
-        ))))
+        )))
+  (cavia-testing "protein HGVS with gene to possible vcf variants with cDNA HGVS"
+    (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
+      (are [hgvs* gene e]
+          (= (protein-hgvs->vcf-variants-with-cdna-hgvs (hgvs/parse hgvs*) gene test-ref-seq-file rgidx) e)
+        "p.T790M" "EGFR" `({:vcf {:chr "chr7", :pos 55181378, :ref "C", :alt "T"} ; cf. rs121434569
+                            :cdna ~(hgvs/parse "NM_005228:c.2369C>T")})
+        "p.L1196M" "ALK" `({:vcf {:chr "chr2", :pos 29220765, :ref "G", :alt "T"} ; cf. rs1057519784
+                            :cdna ~(hgvs/parse "NM_004304:c.3586C>A")})))))


### PR DESCRIPTION
This patch fixes the `hgvs-to-vcf` translation of protein HGVS input and adds refseq ID into the results.

There are cases where it mistranslates HGVS for minus strand gene's mutations (e.g. ALK L1196M). I fixed the minor bug and add tests.