### PR TITLE
Add benchmark code for liftover

### DIFF
--- a/bench/varity/lift_bench.clj
+++ b/bench/varity/lift_bench.clj
@@ -1,0 +1,40 @@
+(ns varity.lift-bench
+  (:require [libra.bench :refer :all]
+            [libra.criterium :as c]
+            [varity.chain :as ch]
+            [varity.lift :as lift]
+            [varity.t-common :refer :all]))
+
+(def src-coords
+  [;; found (+)
+   {:chr "chr1", :pos 10001}
+   {:chr "chr1", :pos 177377}
+   {:chr "chr1", :pos 227418}
+   {:chr "chr1", :pos 743267}
+   {:chr "chr1", :pos 142613288}
+   {:chr "chr1", :pos 143544525}
+   {:chr "chr1", :pos 249240620}
+   {:chr "chrY", :pos 1266342}
+   ;; found (-)
+   {:chr "chr1", :pos 317720}
+   {:chr "chr1", :pos 471368}
+   {:chr "chr1", :pos 144274520}
+   {:chr "chr1", :pos 249060117}
+   {:chr "chr1", :pos 249060118}
+   {:chr "chr1", :pos 249060119}
+   {:chr "chr1", :pos 249060188}
+   {:chr "chr10", :pos 47000000}
+   ;; not found
+   {:chr "chr1", :pos 300}
+   {:chr "chr1", :pos 10000}
+   {:chr "chr1", :pos 177418}
+   {:chr "chr1", :pos 267720}
+   {:chr "chr1", :pos 471369}
+   {:chr "chr1", :pos 143342816}
+   {:chr "chr1", :pos 249240622}
+   {:chr "chr10", :pos 46478862}])
+
+(defbench convert-coord-bench
+  (let [chidx (ch/index (ch/load-chain test-chain-file))]
+    (is (c/quick-bench (doseq [coord src-coords]
+                         (lift/convert-coord coord chidx))))))

--- a/project.clj
+++ b/project.clj
@@ -10,11 +10,15 @@
                  [org.apache.commons/commons-compress "1.16"]
                  [proton "0.1.4"]]
   :plugins [[lein-cloverage "1.0.10"]
-            [lein-codox "0.10.3"]]
+            [lein-codox "0.10.3"]
+            [net.totakke/lein-libra "0.1.2"]]
   :test-selectors {:default (complement :slow)
                    :slow :slow
                    :all (constantly true)}
-  :profiles {:dev {:dependencies [[cavia "0.4.3"]]}
+  :profiles {:dev {:source-paths ["bench"]
+                   :dependencies [[cavia "0.4.3"]
+                                  [criterium "0.4.4"]
+                                  [net.totakke/libra "0.1.1"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
   :deploy-repositories [["snapshots" {:url "https://clojars.org/repo/"
                                       :username [:env/clojars_username :gpg]

--- a/project.clj
+++ b/project.clj
@@ -15,10 +15,10 @@
   :test-selectors {:default (complement :slow)
                    :slow :slow
                    :all (constantly true)}
-  :profiles {:dev {:source-paths ["bench"]
-                   :dependencies [[cavia "0.4.3"]
+  :profiles {:dev {:dependencies [[cavia "0.4.3"]
                                   [criterium "0.4.4"]
                                   [net.totakke/libra "0.1.1"]]}
+             :repl {:source-paths ["bench"]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
   :deploy-repositories [["snapshots" {:url "https://clojars.org/repo/"
                                       :username [:env/clojars_username :gpg]


### PR DESCRIPTION
```console
$ lein libra

Measuring varity.lift-bench

convert-coord-bench (lift_bench.clj:37)

  time: 1.011285 ms, sd: 1.633520 ns
```