### PR TITLE
 Support promoter on variant conversion

### DIFF
--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -179,7 +179,8 @@
 
 (defn cds-pos
   [pos {:keys [strand cds-start cds-end exon-ranges]}]
-  {:pre [(<= (ffirst exon-ranges) pos (second (last exon-ranges)))]}
+  {:pre [(<= (ffirst exon-ranges) pos (second (last exon-ranges)))
+         (<= cds-start cds-end)]}
   (let [pos* (exon-pos pos strand exon-ranges)
         cds-start* (exon-pos cds-start strand exon-ranges)
         cds-end* (exon-pos cds-end strand exon-ranges)

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -73,24 +73,24 @@
 
 (def ^:private pos-index-block 1000000)
 
-(def max-promoter-size 10000)
+(def max-tx-margin 10000)
 
 (defn- locus-index
   [rgs]
   (->> (group-by :chr rgs)
        (map (fn [[chr sub-rgs]]
               (let [fs (round-int (- (apply min (map :tx-start sub-rgs))
-                                     max-promoter-size)
+                                     max-tx-margin)
                                   pos-index-block)
                     le (round-int (+ (apply max (map :tx-end sub-rgs))
-                                     max-promoter-size)
+                                     max-tx-margin)
                                   pos-index-block)]
                 [chr (loop [s fs, ret {}]
                        (if (<= s le)
                          (let [e (+ s pos-index-block)
                                rgs* (filter (fn [{:keys [tx-start tx-end]}]
-                                              (and (<= (- tx-start max-promoter-size) e)
-                                                   (<= s (+ tx-end max-promoter-size))))
+                                              (and (<= (- tx-start max-tx-margin) e)
+                                                   (<= s (+ tx-end max-tx-margin))))
                                             sub-rgs)]
                            (recur e (assoc ret [s e] rgs*)))
                          ret))])))
@@ -121,14 +121,14 @@
                    [:ref-seq s]
                    [:gene s])))
   ([chr pos rgidx] (ref-genes chr pos rgidx 0))
-  ([chr pos rgidx promoter-size]
-   {:pre [(<= 0 promoter-size max-promoter-size)]}
+  ([chr pos rgidx tx-margin]
+   {:pre [(<= 0 tx-margin max-tx-margin)]}
    (let [pos-r (round-int pos pos-index-block)]
      (->> (get-in rgidx [:locus
                          (normalize-chromosome-key chr)
                          [pos-r (+ pos-r pos-index-block)]])
           (filter (fn [{:keys [tx-start tx-end]}]
-                    (<= (- tx-start promoter-size) pos (+ tx-end promoter-size))))))))
+                    (<= (- tx-start tx-margin) pos (+ tx-end tx-margin))))))))
 
 (defn in-any-exon?
   "Returns true if chr:pos is located in any ref-gene exon, else false."

--- a/src/varity/vcf_to_hgvs.clj
+++ b/src/varity/vcf_to_hgvs.clj
@@ -29,8 +29,12 @@
 (defn select-variant
   [var seq-rdr rg]
   (let [nvar (normalize-variant var seq-rdr rg)
-        nvar-cds-coord (rg/cds-coord (+ (:pos nvar) (max (count (:ref nvar)) (count (:alt nvar)))) rg)]
-    (if (nil? (:region nvar-cds-coord))
+        var-start-cds-coord (rg/cds-coord (:pos var) rg)
+        var-end-cds-coord (rg/cds-coord (+ (:pos var) (max (count (:ref var)) (count (:alt var)))) rg)
+        nvar-start-cds-coord (rg/cds-coord (:pos nvar) rg)
+        nvar-end-cds-coord (rg/cds-coord (+ (:pos nvar) (max (count (:ref nvar)) (count (:alt nvar)))) rg)]
+    (if (= (:region var-start-cds-coord) (:region nvar-start-cds-coord)
+           (:region var-end-cds-coord) (:region nvar-end-cds-coord))
       nvar
       var)))
 
@@ -42,26 +46,33 @@
   allowed. ref-seq must be a path to reference or an instance which implements
   cljam.io.protocols/ISequenceReader. ref-gene must be a path to
   refGene.txt(.gz), ref-gene index, or a ref-gene entity. A returned sequence
-  consists of cDNA HGVS defined in clj-hgvs."
-  {:arglists '([variant ref-seq ref-gene])}
-  (fn [variant ref-seq ref-gene]
+  consists of cDNA HGVS defined in clj-hgvs.
+
+  Options:
+
+    :promoter-size  The length of promoter, up to a maximum of 10000, default
+                    5000."
+  {:arglists '([variant ref-seq ref-gene]
+               [variant ref-seq ref-gene options])}
+  (fn [_ ref-seq ref-gene & _]
     (dispatch ref-seq ref-gene)))
 
 (defmethod vcf-variant->cdna-hgvs :ref-seq-path
-  [variant ref-seq ref-gene]
+  [variant ref-seq ref-gene & [options]]
   (with-open [seq-rdr (cseq/reader ref-seq)]
-    (doall (vcf-variant->cdna-hgvs variant seq-rdr ref-gene))))
+    (doall (vcf-variant->cdna-hgvs variant seq-rdr ref-gene options))))
 
 (defmethod vcf-variant->cdna-hgvs :ref-gene-path
-  [variant seq-rdr ref-gene]
+  [variant seq-rdr ref-gene & [options]]
   (let [rgidx (rg/index (rg/load-ref-genes ref-gene))]
-    (vcf-variant->cdna-hgvs variant seq-rdr rgidx)))
+    (vcf-variant->cdna-hgvs variant seq-rdr rgidx options)))
 
 (defmethod vcf-variant->cdna-hgvs :ref-gene-index
-  [{:keys [chr pos ref alt]} seq-rdr rgidx]
-  (let [chr (normalize-chromosome-key chr)]
+  [{:keys [chr pos ref alt]} seq-rdr rgidx & [options]]
+  (let [{:keys [promoter-size] :or {promoter-size 5000}} options
+        chr (normalize-chromosome-key chr)]
     (if (valid-ref? seq-rdr chr pos ref)
-      (->> (rg/ref-genes chr pos rgidx)
+      (->> (rg/ref-genes chr pos rgidx promoter-size)
            (filter cdna-ref-gene?)
            (map (fn [rg]
                   (assoc (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
@@ -72,7 +83,7 @@
       (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos))))))
 
 (defmethod vcf-variant->cdna-hgvs :ref-gene-entity
-  [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg}]
+  [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg} & _]
   (if (valid-ref? seq-rdr chr pos ref)
     (let [nv (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
                              seq-rdr rg)]
@@ -89,7 +100,7 @@
   refGene.txt(.gz), ref-gene index, or a ref-gene entity. A returned sequence
   consists of protein HGVS defined in clj-hgvs."
   {:arglists '([variant ref-seq ref-gene])}
-  (fn [variant ref-seq ref-gene]
+  (fn [_ ref-seq ref-gene]
     (dispatch ref-seq ref-gene)))
 
 (defmethod vcf-variant->protein-hgvs :ref-seq-path
@@ -134,26 +145,33 @@
   ref-seq must be a path to reference or an instance which implements
   cljam.io.protocols/ISequenceReader. ref-gene must be a path to
   refGene.txt(.gz), ref-gene index, or a ref-gene entity. A returned sequence
-  consists of maps, each having :cdna and :protein HGVS defined in clj-hgvs."
-  {:arglists '([variant ref-seq ref-gene])}
-  (fn [variant ref-seq ref-gene]
+  consists of maps, each having :cdna and :protein HGVS defined in clj-hgvs.
+
+  Options:
+
+    :promoter-size  The length of promoter, up to a maximum of 10000, default
+                    5000."
+  {:arglists '([variant ref-seq ref-gene]
+               [variant ref-seq ref-gene options])}
+  (fn [_ ref-seq ref-gene & _]
     (dispatch ref-seq ref-gene)))
 
 (defmethod vcf-variant->hgvs :ref-seq-path
-  [variant ref-seq ref-gene]
+  [variant ref-seq ref-gene & [options]]
   (with-open [seq-rdr (cseq/reader ref-seq)]
-    (doall (vcf-variant->hgvs variant seq-rdr ref-gene))))
+    (doall (vcf-variant->hgvs variant seq-rdr ref-gene options))))
 
 (defmethod vcf-variant->hgvs :ref-gene-path
-  [variant seq-rdr ref-gene]
+  [variant seq-rdr ref-gene & [options]]
   (let [rgidx (rg/index (rg/load-ref-genes ref-gene))]
-    (vcf-variant->hgvs variant seq-rdr rgidx)))
+    (vcf-variant->hgvs variant seq-rdr rgidx options)))
 
 (defmethod vcf-variant->hgvs :ref-gene-index
-  [{:keys [chr pos ref alt]} seq-rdr rgidx]
-  (let [chr (normalize-chromosome-key chr)]
+  [{:keys [chr pos ref alt]} seq-rdr rgidx & [options]]
+  (let [{:keys [promoter-size] :or {promoter-size 5000}} options
+        chr (normalize-chromosome-key chr)]
     (if (valid-ref? seq-rdr chr pos ref)
-      (->> (rg/ref-genes chr pos rgidx)
+      (->> (rg/ref-genes chr pos rgidx promoter-size)
            (filter cdna-ref-gene?)
            (map (fn [rg]
                   (assoc (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
@@ -167,7 +185,7 @@
       (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos))))))
 
 (defmethod vcf-variant->hgvs :ref-gene-entity
-  [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg}]
+  [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg} & _]
   (if (valid-ref? seq-rdr chr pos ref)
     (let [{:keys [pos] :as nv} (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
                                                seq-rdr rg)]

--- a/src/varity/vcf_to_hgvs.clj
+++ b/src/varity/vcf_to_hgvs.clj
@@ -23,6 +23,9 @@
       (instance? varity.ref_gene.RefGeneIndex ref-gene) :ref-gene-index
       (map? ref-gene) :ref-gene-entity)))
 
+(defn- cdna-ref-gene? [rg]
+  (some? (re-matches #"NM_\d+(\.\d+)?" (:name rg))))
+
 (defn select-variant
   [var seq-rdr rg]
   (let [nvar (normalize-variant var seq-rdr rg)
@@ -59,6 +62,7 @@
   (let [chr (normalize-chromosome-key chr)]
     (if (valid-ref? seq-rdr chr pos ref)
       (->> (rg/ref-genes chr pos rgidx)
+           (filter cdna-ref-gene?)
            (map (fn [rg]
                   (assoc (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
                                          seq-rdr rg)
@@ -103,6 +107,7 @@
   (let [chr (normalize-chromosome-key chr)]
     (if (valid-ref? seq-rdr chr pos ref)
       (->> (rg/ref-genes chr pos rgidx)
+           (filter cdna-ref-gene?)
            (map (fn [rg]
                   (assoc (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
                                          seq-rdr rg)
@@ -149,6 +154,7 @@
   (let [chr (normalize-chromosome-key chr)]
     (if (valid-ref? seq-rdr chr pos ref)
       (->> (rg/ref-genes chr pos rgidx)
+           (filter cdna-ref-gene?)
            (map (fn [rg]
                   (assoc (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
                                          seq-rdr rg)

--- a/src/varity/vcf_to_hgvs.clj
+++ b/src/varity/vcf_to_hgvs.clj
@@ -50,8 +50,8 @@
 
   Options:
 
-    :promoter-size  The length of promoter, up to a maximum of 10000, default
-                    5000."
+    :tx-margin  The length of transcription margin, up to a maximum of 10000,
+                default 5000."
   {:arglists '([variant ref-seq ref-gene]
                [variant ref-seq ref-gene options])}
   (fn [_ ref-seq ref-gene & _]
@@ -69,10 +69,10 @@
 
 (defmethod vcf-variant->cdna-hgvs :ref-gene-index
   [{:keys [chr pos ref alt]} seq-rdr rgidx & [options]]
-  (let [{:keys [promoter-size] :or {promoter-size 5000}} options
+  (let [{:keys [tx-margin] :or {tx-margin 5000}} options
         chr (normalize-chromosome-key chr)]
     (if (valid-ref? seq-rdr chr pos ref)
-      (->> (rg/ref-genes chr pos rgidx promoter-size)
+      (->> (rg/ref-genes chr pos rgidx tx-margin)
            (filter cdna-ref-gene?)
            (map (fn [rg]
                   (assoc (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
@@ -149,8 +149,8 @@
 
   Options:
 
-    :promoter-size  The length of promoter, up to a maximum of 10000, default
-                    5000."
+    :tx-margin  The length of transcription margin, up to a maximum of 10000,
+                default 5000."
   {:arglists '([variant ref-seq ref-gene]
                [variant ref-seq ref-gene options])}
   (fn [_ ref-seq ref-gene & _]
@@ -168,10 +168,10 @@
 
 (defmethod vcf-variant->hgvs :ref-gene-index
   [{:keys [chr pos ref alt]} seq-rdr rgidx & [options]]
-  (let [{:keys [promoter-size] :or {promoter-size 5000}} options
+  (let [{:keys [tx-margin] :or {tx-margin 5000}} options
         chr (normalize-chromosome-key chr)]
     (if (valid-ref? seq-rdr chr pos ref)
-      (->> (rg/ref-genes chr pos rgidx promoter-size)
+      (->> (rg/ref-genes chr pos rgidx tx-margin)
            (filter cdna-ref-gene?)
            (map (fn [rg]
                   (assoc (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}

--- a/src/varity/vcf_to_hgvs/cdna.clj
+++ b/src/varity/vcf_to_hgvs/cdna.clj
@@ -10,7 +10,7 @@
   (->> (common/read-sequence-stepwise-backward
         seq-rdr
         {:chr (:chr rg)
-         :start (- (:tx-start rg) rg/max-promoter-size)
+         :start (- (:tx-start rg) rg/max-tx-margin)
          :end (dec pos)}
         100)
        (map (fn [seq*]
@@ -29,7 +29,7 @@
         seq-rdr
         {:chr (:chr rg)
          :start pos
-         :end (+ (:tx-end rg) rg/max-promoter-size)}
+         :end (+ (:tx-end rg) rg/max-tx-margin)}
         100)
        (map (fn [seq*]
               (let [nseq* (count seq*)]

--- a/src/varity/vcf_to_hgvs/cdna.clj
+++ b/src/varity/vcf_to_hgvs/cdna.clj
@@ -8,7 +8,11 @@
 (defn- repeat-info-forward
   [seq-rdr rg pos ins]
   (->> (common/read-sequence-stepwise-backward
-        seq-rdr {:chr (:chr rg), :start (:tx-start rg), :end (dec pos)} 100)
+        seq-rdr
+        {:chr (:chr rg)
+         :start (- (:tx-start rg) rg/max-promoter-size)
+         :end (dec pos)}
+        100)
        (map (fn [seq*]
               (let [nseq* (count seq*)]
                 (if-let [[unit ref-repeat :as ri] (common/repeat-info seq* (inc nseq*) ins)]
@@ -22,7 +26,11 @@
 (defn- repeat-info-backward
   [seq-rdr rg pos ins]
   (->> (common/read-sequence-stepwise
-        seq-rdr {:chr (:chr rg), :start pos, :end (:tx-end rg)} 100)
+        seq-rdr
+        {:chr (:chr rg)
+         :start pos
+         :end (+ (:tx-end rg) rg/max-promoter-size)}
+        100)
        (map (fn [seq*]
               (let [nseq* (count seq*)]
                 (if-let [[unit ref-repeat :as ri] (common/repeat-info (revcomp-bases seq*)

--- a/src/varity/vcf_to_hgvs/common.clj
+++ b/src/varity/vcf_to_hgvs/common.clj
@@ -140,7 +140,7 @@
   (->> (read-sequence-stepwise seq-rdr
                                {:chr chr
                                 :start pos
-                                :end (+ (:tx-end rg) rg/max-promoter-size)}
+                                :end (+ (:tx-end rg) rg/max-tx-margin)}
                                100)
        (keep (fn [seq*]
                (let [nvar (normalize-variant* {:pos 1, :ref ref, :alt alt} seq* "+")]
@@ -154,7 +154,7 @@
   [{:keys [chr pos ref alt]} seq-rdr rg]
   (->> (read-sequence-stepwise-backward seq-rdr
                                         {:chr chr
-                                         :start (- (:tx-start rg) rg/max-promoter-size)
+                                         :start (- (:tx-start rg) rg/max-tx-margin)
                                          :end (+ pos (count ref) -1)}
                                         100)
        (keep (fn [seq*]

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -13,6 +13,7 @@
         ;; substitution
         "NM_005228:c.2573T>G" '({:chr "chr7", :pos 55191822, :ref "T", :alt "G"}) ; cf. rs121434568
         "NM_005957:c.665C>T" '({:chr "chr1", :pos 11796321, :ref "G", :alt "A"}) ; cf. rs1801133
+        "NM_198253:c.-124C>T" '({:chr "chr5", :pos 1295113, :ref "G", :alt "A"}) ; promoter
 
         ;; deletion
         "NM_198317:c.1157_1158delCG" '({:chr "chr1", :pos 963222, :ref "GCG", :alt "G"})
@@ -46,6 +47,7 @@
         ;; substitution
         "c.2573T>G" "EGFR" '({:chr "chr7", :pos 55191822, :ref "T", :alt "G"}) ; cf. rs121434568
         "c.665C>T" "MTHFR" '({:chr "chr1", :pos 11796321, :ref "G", :alt "A"}) ; cf. rs1801133
+        "c.-124C>T" "TERT" '({:chr "chr5", :pos 1295113, :ref "G", :alt "A"}) ; promoter
 
         ;; deletion
         "c.1157_1158delCG" "KLHL17" '({:chr "chr1", :pos 963222, :ref "GCG", :alt "G"})

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -46,6 +46,8 @@
   (testing "strand +"
     (are [p s e r] (= (coord/format
                        (rg/cds-coord p {:strand "+"
+                                        :tx-start 2
+                                        :tx-end 11
                                         :cds-start s
                                         :cds-end e
                                         :exon-ranges [[2 4] [8 11]]}))
@@ -60,10 +62,14 @@
       3  9 11 "-3"
       9  2 3  "*3"
       5  9 11 "-2+1"
-      13 2 3  "*5+2"))
+      7  2 3  "*2-1"
+      1  9 11 "-5"
+      13 2 3  "*7"))
   (testing "strand -"
     (are [p s e r] (= (coord/format
                        (rg/cds-coord p {:strand "-"
+                                        :tx-start 2
+                                        :tx-end 11
                                         :cds-start s
                                         :cds-end e
                                         :exon-ranges [[2 4] [8 11]]}))
@@ -77,8 +83,10 @@
       5  2 11 "5-1"
       9  2 3  "-3"
       3  9 11 "*3"
-      12 2 3  "-5-1"
-      5  9 11 "*2-1")))
+      7  2 3  "-2+1"
+      5  9 11 "*2-1"
+      13 2 3  "-7"
+      1  9 11 "*5")))
 
 (defn- cds-coord
   [chr pos rgidx]
@@ -114,7 +122,9 @@
       "-3"   9 11 3
       "*3"   2 3  9
       "-2+1" 9 11 5
-      "*5+2" 2 3  13))
+      "*2-1" 2 3  7
+      "-5"   9 11 1
+      "*7"   2 3  13))
   (testing "strand -"
     (are [c s e r] (= (rg/cds-coord->genomic-pos (coord/parse-cdna-coordinate c)
                                                  {:strand "-"
@@ -131,5 +141,7 @@
       "5-1"  2 11 5
       "-3"   2 3  9
       "*3"   9 11 3
-      "-5-1" 2 3  12
-      "*2-1" 9 11 5)))
+      "-2+1" 2 3  7
+      "*2-1" 9 11 5
+      "-7"   2 3  13
+      "*5"   9 11 1)))

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -100,12 +100,12 @@
                                     "NM_057166:c.4242+6[9]"
                                     "NM_057167:c.5445+6[9]") ; cf. rs11385011 (-)
         )))
-  (cavia-testing "promoter size"
+  (cavia-testing "tx-margin"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
-      (are [chr pos ref alt psize e]
+      (are [chr pos ref alt tx-margin e]
           (= (vcf-variant->cdna-hgvs-texts {:chr chr, :pos pos, :ref ref, :alt alt}
                                            test-ref-seq-file rgidx
-                                           {:promoter-size psize}) e)
+                                           {:tx-margin tx-margin}) e)
         "chr5" 1295113 "G" "A" 5000 '("NM_001193376:c.-124C>T"
                                       "NM_198253:c.-124C>T")
         "chr5" 1295113 "G" "A" 0 '())))


### PR DESCRIPTION
Newly supports promoter region on variant conversion.

```clojure
(v2h/vcf-variant->hgvs {:chr "chr5", :pos 1295113, :ref "G", :alt "A"}
                       "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> ({:cdna {:transcript "NM_001193376",
;;            :kind :cdna,
;;            :mutation #clj_hgvs.mutation.DNASubstitution
;;            {:coord #clj_hgvs.coordinate.CDNACoordinate
;;             {:position 124, :offset 0, :region :upstream},
;;             :ref "C",
;;             :type ">",
;;             :alt "T"}},
;;     :protein nil}
;;    {:cdna {:transcript "NM_198253",
;;            :kind :cdna,
;;            :mutation #clj_hgvs.mutation.DNASubstitution
;;            {:coord #clj_hgvs.coordinate.CDNACoordinate
;;             {:position 124, :offset 0, :region :upstream},
;;             :ref "C",
;;             :type ">",
;;             :alt "T"}},
;;     :protein nil})

(h2v/hgvs->vcf-variants (hgvs/parse "NM_198253:c.-124C>T")
                        "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> ({:chr "chr5", :pos 1295113, :ref "G", :alt "A"})
```

The default transcription margin is `5000`. You can change this value by `:tx-margin` option.

```clojure
(v2h/vcf-variant->hgvs {:chr "chr5", :pos 1295113, :ref "G", :alt "A"}
                       "path/to/hg38.fa" "path/to/refGene.txt.gz"
                       {:tx-margin 0})
;;=> ()
```