### PR TITLE
 Return p.? w/ warning when CDS is indivisible by 3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :min-lein-version "2.7.0"
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
+                 [org.clojure/tools.logging "0.4.1"]
                  [clj-hgvs "0.2.3"]
                  [cljam "0.5.1"]
                  [org.apache.commons/commons-compress "1.16.1"]

--- a/test/varity/t_common.clj
+++ b/test/varity/t_common.clj
@@ -1,5 +1,7 @@
 (ns varity.t-common
   (:require [clojure.java.io :as io]
+            [clojure.tools.logging :refer [*logger-factory*]]
+            [clojure.tools.logging.impl :refer [disabled-logger-factory]]
             [clojure.test :refer [deftest testing]]
             [cavia.core :as cavia :refer [defprofile with-profile]]))
 
@@ -29,6 +31,10 @@
   `(testing ~s
      (prepare-cavia!)
      ~@body))
+
+(defn disable-log-fixture [f]
+  (binding [*logger-factory* disabled-logger-factory]
+    (f)))
 
 (def test-ref-seq-file (cavia/resource prof "test.2bit"))
 (def test-ref-gene-file (cavia/resource prof "test-refGene.txt.gz"))

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -5,6 +5,8 @@
             [varity.vcf-to-hgvs :refer :all]
             [varity.t-common :refer :all]))
 
+(use-fixtures :once disable-log-fixture)
+
 (defn- vcf-variant->cdna-hgvs-texts
   [variant seq-rdr rgidx & [options]]
   (map #(hgvs/format % {:show-bases? true
@@ -172,6 +174,9 @@
         "chr7" 55181876 "A" "T" '("p.=") ; not actual example (+)
         "chr7" 55181874 "TGAT" "T" '("p.=") ; not actual example (+)
         "chr7" 55181876 "A" "AGGT" '("p.=") ; not actual example (+)
+
+        ;; unknown
+        "chr12" 40393453 "G" "A" '("p.?") ; not actual example (+)
         )))
   (cavia-testing "throws Exception if inputs are illegal"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]


### PR DESCRIPTION
Fixes a problem that protein conversion is wrong or fails when CDS sequence is indivisible by three. `p.?` is returned with a warning message in that case.

before:

```clojure
(vcf-variant->protein-hgvs {:chr "chr12" :pos 40393453 :ref "G" :alt "A"} "path/to/hg38.2bit" "path/to/refGene.txt.gz")
;; NullPointerException   clojure.lang.Numbers.ops (Numbers.java:1018)
```

after:

```clojure
(vcf-variant->protein-hgvs {:chr "chr12" :pos 40393453 :ref "G" :alt "A"} "path/to/hg38.2bit" "path/to/refGene.txt.gz")
;; Aug 20, 2018 7:14:55 PM varity.vcf-to-hgvs.protein invoke
;; WARNING: CDS length is indivisible by 3: 24668 (NM_173600, MUC19)
;;=> ({:transcript nil,
;;     :kind :protein,
;;     :mutation #clj_hgvs.mutation.ProteinUnknownMutation{}})
```