### PR TITLE
Fix the translation condition of termination substitution with frameshift

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -179,8 +179,9 @@
                 (or (= (+ base-ppos offset) 1)
                     (= (+ base-ppos offset) (count ref-prot-seq))) :extension
                 (and (pos? nprefo) (= (first palt-only) \*)) :substitution
-                (not= ref-prot-rest alt-prot-rest) (if (= (first alt-prot-rest) \*)
-                                                     :fs-ter-substitution
+                (not= ref-prot-rest alt-prot-rest) (if (or (and (empty? palt-only)
+                                                                (= (first alt-prot-rest) \*))
+                                                           (= (last palt-only) \*)) :fs-ter-substitution
                                                      :frame-shift)
                 (or (and (zero? nprefo) (zero? npalto))
                     (and (= nprefo 1) (= npalto 1))) :substitution
@@ -195,8 +196,12 @@
                 :else (throw (IllegalArgumentException. "Unsupported variant")))]
         {:type (if (= t :fs-ter-substitution) :substitution t)
          :pos base-ppos
-         :ref pref
-         :alt (if (= t :fs-ter-substitution) (str palt \*) palt)}))))
+         :ref (if (= t :fs-ter-substitution)
+                (str pref (subs ref-prot-rest 0 (max 0 (inc (- (count palt) (count pref))))))
+                pref)
+         :alt (if (= t :fs-ter-substitution)
+                (str palt \*)
+                palt)}))))
 
 (defn- protein-substitution
   [ppos pref palt]

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -138,6 +138,7 @@
         "chr6" 33086236 "TA" "T" '("p.*259=") ; cf. rs67523850 (deletion in border of UTR)
         "chr7" 152247986 "G" "GT" '("p.Y816*") ; cf. rs150073007 (-, nonsense mutation)
         "chr17" 31159027 "TGC" "T" '("p.A75*") ; not actual example (+, nonsense in del case)
+        "chr2" 47478341 "TG" "T" '("p.L762*" "p.L696*") ;; rs786204050 (+) frameshift with termination
 
         ;; deletion
         "chr1" 1286041 "CCTT" "C" '("p.F227del")
@@ -165,6 +166,7 @@
         ;; Frame shift
         "chr1" 69567 "A" "AT" '("p.L160Sfs*7")
         "chr1" 963222 "GCG" "G" '("p.A386Gfs*12")
+        "chr2" 47478341 "T" "TGG" '("p.L762Gfs*2" "p.L696Gfs*2")
 
         ;; Extension
         "chr2" 189011772 "T" "C" '("p.*1467Qext*45") ; cf. ClinVar 101338


### PR DESCRIPTION
This PR fixes the translation condition of termination substitution with frameshift in `varity.vcf-to-hgvs.protein`.

Translating `{:chr "chr2" :pos 47478341 :ref "T" :alt "TGG"}` results in `Assert failed` because `pref` in [src/varity/vcf_to_hgvs/protein.clj#L202](https://github.com/chrovis/varity/blob/master/src/varity/vcf_to_hgvs/protein.clj#L202) become empty. This is very rare case.

**Tests**

- lein check 🆗 
- lein test :all 🆗 
