### PR TITLE
Fix normalization of a variant containing long ref

### DIFF
--- a/src/varity/vcf_to_hgvs/common.clj
+++ b/src/varity/vcf_to_hgvs/common.clj
@@ -158,12 +158,13 @@
                                          :end (+ pos (count ref) -1)}
                                         100)
        (keep (fn [seq*]
-               (let [offset (- (count seq*) (count ref))
-                     nvar (normalize-variant* {:pos (inc offset), :ref ref, :alt alt} seq* :reverse)]
-                 (if (> (:pos nvar) (max (count ref) (count alt)))
-                   (-> nvar
-                       (assoc :chr chr)
-                       (update :pos + (- pos offset) -1))))))
+               (let [offset (- (count seq*) (count ref))]
+                 (when (>= offset 0)
+                   (let [nvar (normalize-variant* {:pos (inc offset), :ref ref, :alt alt} seq* :reverse)]
+                     (if (> (:pos nvar) (max (count ref) (count alt)))
+                       (-> nvar
+                           (assoc :chr chr)
+                           (update :pos + (- pos offset) -1))))))))
        (first)))
 
 (defn normalize-variant

--- a/test/varity/vcf_to_hgvs/common_test.clj
+++ b/test/varity/vcf_to_hgvs/common_test.clj
@@ -1,6 +1,8 @@
 (ns varity.vcf-to-hgvs.common-test
   (:require [clojure.test :refer :all]
-            [varity.vcf-to-hgvs.common :refer :all]))
+            [cljam.io.sequence :as cseq]
+            [varity.vcf-to-hgvs.common :refer :all]
+            [varity.t-common :refer :all]))
 
 (deftest diff-bases-test
   (testing "diff-bases returns a vector of diff info"
@@ -56,3 +58,10 @@
       {:pos 7, :ref "TAGT", :alt "T"} :forward {:pos 10, :ref "TAGT", :alt "T"}
       {:pos 7, :ref "T", :alt "TAGT"} :reverse {:pos 4, :ref "C", :alt "CAGT"}
       {:pos 7, :ref "TAGT", :alt "T"} :reverse {:pos 4, :ref "CAGT", :alt "C"})))
+
+(defslowtest normalize-variant-test
+  (cavia-testing "normalize without error"
+    (with-open [seq-rdr (cseq/reader test-ref-seq-file)]
+      (are [v rg] (map? (normalize-variant v seq-rdr rg))
+        {:chr "chr17", :pos 43125270, :ref "CCTTTACCCAGAGCAGAGGGTGAAGGCCTCCTGAGCGCAGGGGCCCAGTTATCTGAGAAACCCCACAGCCTGTCCCCCGTCCAGGAAGTCTCAGCGAGCTCACGCCGCGCAGTCGCAGTTTTAATTTATCTGTAATTCCCGCGCTTTTCCGTTGCCACGGAAACCAAGGGGCTACCGCTAAG", :alt "C"}
+        {:tx-start 43044295, :strand :reverse}))))


### PR DESCRIPTION
I found variant normalization throws an error when a variant containing long ref and a reverse-strand ref-gene are supplied.

```clj
(require '[varity.vcf-to-hgvs :as v2h])

(v2h/vcf-variant->hgvs {:chr "chr17"
                        :pos 43125270
                        :ref "CCTTTACCCAGAGCAGAGGGTGAAGGCCTCCTGAGCGCAGGGGCCCAGTTATCTGAGAAACCCCACAGCCTGTCCCCCGTCCAGGAAGTCTCAGCGAGCTCACGCCGCGCAGTCGCAGTTTTAATTTATCTGTAATTCCCGCGCTTTTCCGTTGCCACGGAAACCAAGGGGCTACCGCTAAG"
                        :alt "C"}
                       "path/to/hg38.fa"
                       "path/to/refGene.txt.gz")
;; StringIndexOutOfBoundsException begin -81, end 100, length 100  java.lang.String.checkBoundsBeginEnd (String.java:3107)
```

This PR fixes that problem.

```clj
(v2h/vcf-variant->hgvs {:chr "chr17"
                        :pos 43125270
                        :ref "CCTTTACCCAGAGCAGAGGGTGAAGGCCTCCTGAGCGCAGGGGCCCAGTTATCTGAGAAACCCCACAGCCTGTCCCCCGTCCAGGAAGTCTCAGCGAGCTCACGCCGCGCAGTCGCAGTTTTAATTTATCTGTAATTCCCGCGCTTTTCCGTTGCCACGGAAACCAAGGGGCTACCGCTAAG"
                        :alt "C"}
                       "path/to/hg38.fa"
                       "path/to/refGene.txt.gz")
;;=> ({:cdna {:transcript "NM_007298",
;;   ...
```

I confirmed `lein test :all` passed.