### PR TITLE
Add debug printing option

### DIFF
--- a/src/varity/vcf_to_hgvs.clj
+++ b/src/varity/vcf_to_hgvs.clj
@@ -1,9 +1,12 @@
 (ns varity.vcf-to-hgvs
   "Functions to convert a VCF-style variant into HGVS."
-  (:require [cljam.io.sequence :as cseq]
+  (:require [clojure.tools.logging :as log]
+            [cljam.io.sequence :as cseq]
             [cljam.io.util :as io-util]
             [cljam.util.chromosome :refer [normalize-chromosome-key]]
+            [proton.string :as pstring]
             [varity.ref-gene :as rg]
+            [varity.vcf-to-hgvs.genome :as genome]
             [varity.vcf-to-hgvs.cdna :as cdna]
             [varity.vcf-to-hgvs.common :refer [normalize-variant]]
             [varity.vcf-to-hgvs.protein :as prot]))
@@ -31,7 +34,7 @@
   (if-let [nvar (normalize-variant var seq-rdr rg)]
     (let [var-start-cds-coord (rg/cds-coord (:pos var) rg)
           var-end-cds-coord (rg/cds-coord (+ (:pos var) (max (count (:ref var)) (count (:alt var)))) rg)
-          nvar-start-cds-coord (rg/cds-coord (:pos nvar) rg) ;; !
+          nvar-start-cds-coord (rg/cds-coord (:pos nvar) rg)
           nvar-end-cds-coord (rg/cds-coord (+ (:pos nvar) (max (count (:ref nvar)) (count (:alt nvar)))) rg)]
       (if (= (:region var-start-cds-coord) (:region nvar-start-cds-coord)
              (:region var-end-cds-coord) (:region nvar-end-cds-coord))
@@ -43,6 +46,25 @@
   [var rg]
   (and (<= (:cds-start rg) (+ (:pos var) (count (:ref var))))
        (<= (:pos var) (:cds-end rg))))
+
+(defn- print-debug-info
+  [var seq-rdr rg]
+  (try
+    (println " variant:" (-> (select-keys var [:chr :pos :ref :alt])
+                             (update :ref pstring/prune 20)
+                             (update :alt pstring/prune 20)
+                             str))
+    (println "ref-gene:" (str (select-keys rg [:name :name2 :strand])))
+    (newline)
+    (println (genome/debug-string var seq-rdr rg))
+    (newline)
+    (println (cdna/debug-string var seq-rdr rg))
+    (when (cds-affected? var rg)
+      (newline)
+      (println (prot/debug-string var seq-rdr rg)))
+    (newline)
+    (catch Exception e
+      (log/warn "Debug printing throws error" e))))
 
 ;;; -> cDNA HGVS
 
@@ -57,7 +79,8 @@
   Options:
 
     :tx-margin  The length of transcription margin, up to a maximum of 10000,
-                default 5000."
+                default 5000.
+    :verbose?   Print debug information, default false."
   {:arglists '([variant ref-seq ref-gene]
                [variant ref-seq ref-gene options])}
   (fn [_ ref-seq ref-gene & _]
@@ -84,15 +107,20 @@
                   (assoc (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
                                          seq-rdr rg)
                          :rg rg)))
-           (map #(cdna/->hgvs % seq-rdr (:rg %)))
+           (map (fn [{:keys [rg] :as m}]
+                  (when (:verbose? options)
+                    (print-debug-info m seq-rdr rg))
+                  (cdna/->hgvs m seq-rdr rg)))
            distinct)
       (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos))))))
 
 (defmethod vcf-variant->cdna-hgvs :ref-gene-entity
-  [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg} & _]
+  [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg} & [options]]
   (if (valid-ref? seq-rdr chr pos ref)
     (let [nv (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
                              seq-rdr rg)]
+      (when (:verbose? options)
+        (print-debug-info nv seq-rdr rg))
       (cdna/->hgvs (assoc nv :rg rg) seq-rdr rg))
     (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos)))))
 
@@ -104,23 +132,28 @@
   allowed. ref-seq must be a path to reference or an instance which implements
   cljam.io.protocols/ISequenceReader. ref-gene must be a path to
   refGene.txt(.gz), ref-gene index, or a ref-gene entity. A returned sequence
-  consists of protein HGVS defined in clj-hgvs."
-  {:arglists '([variant ref-seq ref-gene])}
-  (fn [_ ref-seq ref-gene]
+  consists of protein HGVS defined in clj-hgvs.
+
+  Options:
+
+    :verbose?  Print debug information, default false."
+  {:arglists '([variant ref-seq ref-gene]
+               [variant ref-seq ref-gene options])}
+  (fn [_ ref-seq ref-gene & _]
     (dispatch ref-seq ref-gene)))
 
 (defmethod vcf-variant->protein-hgvs :ref-seq-path
-  [variant ref-seq ref-gene]
+  [variant ref-seq ref-gene & [options]]
   (with-open [seq-rdr (cseq/reader ref-seq)]
-    (doall (vcf-variant->protein-hgvs variant seq-rdr ref-gene))))
+    (doall (vcf-variant->protein-hgvs variant seq-rdr ref-gene options))))
 
 (defmethod vcf-variant->protein-hgvs :ref-gene-path
-  [variant seq-rdr ref-gene]
+  [variant seq-rdr ref-gene & [options]]
   (let [rgidx (rg/index (rg/load-ref-genes ref-gene))]
-    (vcf-variant->protein-hgvs variant seq-rdr rgidx)))
+    (vcf-variant->protein-hgvs variant seq-rdr rgidx options)))
 
 (defmethod vcf-variant->protein-hgvs :ref-gene-index
-  [{:keys [chr pos ref alt]} seq-rdr rgidx]
+  [{:keys [chr pos ref alt]} seq-rdr rgidx & [options]]
   (let [chr (normalize-chromosome-key chr)]
     (if (valid-ref? seq-rdr chr pos ref)
       (->> (rg/ref-genes chr pos rgidx)
@@ -130,16 +163,21 @@
                                          seq-rdr rg)
                          :rg rg)))
            (filter #(cds-affected? % (:rg %)))
-           (keep #(prot/->hgvs % seq-rdr (:rg %)))
+           (keep (fn [{:keys [rg] :as m}]
+                   (when (:verbose? options)
+                     (print-debug-info m seq-rdr rg))
+                   (prot/->hgvs m seq-rdr rg)))
            distinct)
       (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos))))))
 
 (defmethod vcf-variant->protein-hgvs :ref-gene-entity
-  [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg}]
+  [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg} & [options]]
   (if (valid-ref? seq-rdr chr pos ref)
     (let [nv (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
                              seq-rdr rg)]
-      (if (cds-affected? nv rg)
+      (when (cds-affected? nv rg)
+        (when (:verbose? options)
+          (print-debug-info nv seq-rdr rg))
         (prot/->hgvs (assoc nv :rg rg) seq-rdr rg)))
     (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos)))))
 
@@ -156,7 +194,8 @@
   Options:
 
     :tx-margin  The length of transcription margin, up to a maximum of 10000,
-                default 5000."
+                default 5000.
+    :verbose?   Print debug information, default false."
   {:arglists '([variant ref-seq ref-gene]
                [variant ref-seq ref-gene options])}
   (fn [_ ref-seq ref-gene & _]
@@ -184,6 +223,8 @@
                                          seq-rdr rg)
                          :rg rg)))
            (map (fn [{:keys [rg] :as m}]
+                  (when (:verbose? options)
+                    (print-debug-info m seq-rdr rg))
                   {:cdna (cdna/->hgvs m seq-rdr rg)
                    :protein (if (cds-affected? m rg)
                               (prot/->hgvs m seq-rdr rg))}))
@@ -191,10 +232,13 @@
       (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos))))))
 
 (defmethod vcf-variant->hgvs :ref-gene-entity
-  [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg} & _]
+  [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg} & options]
   (if (valid-ref? seq-rdr chr pos ref)
     (let [nv (select-variant {:chr chr, :pos pos, :ref ref, :alt alt}
                              seq-rdr rg)]
+      (when (:verbose? options)
+        (print-debug-info nv seq-rdr rg))
+
       {:cdna (cdna/->hgvs nv seq-rdr rg)
        :protein (if (cds-affected? nv rg)
                   (prot/->hgvs nv seq-rdr rg))})

--- a/src/varity/vcf_to_hgvs/common.clj
+++ b/src/varity/vcf_to_hgvs/common.clj
@@ -184,6 +184,15 @@
     :forward (normalize-variant-forward variant seq-rdr rg)
     :reverse (normalize-variant-backward variant seq-rdr rg)))
 
+(defn alt-sequence
+  "Returns sequence a variant applied."
+  [ref-seq seq-start pos ref alt]
+  (let [pos* (inc (- pos seq-start))]
+    (str (subs ref-seq 0 (max 0 (dec pos*)))
+         alt
+         (subs ref-seq (min (count ref-seq)
+                            (+ (dec pos*) (count ref)))))))
+
 (defn split-string-at [s x]
   (cond
     (integer? x) [(subs s 0 x) (subs s x)]

--- a/src/varity/vcf_to_hgvs/common.clj
+++ b/src/varity/vcf_to_hgvs/common.clj
@@ -183,3 +183,13 @@
   (case (:strand rg)
     :forward (normalize-variant-forward variant seq-rdr rg)
     :reverse (normalize-variant-backward variant seq-rdr rg)))
+
+(defn split-string-at [s x]
+  (cond
+    (integer? x) [(subs s 0 x) (subs s x)]
+    (sequential? x) (let [[n & r] x]
+                      (if n
+                        (let [[s1 s2] (split-string-at s n)]
+                          (vec (cons s1 (split-string-at s2 (map #(- % n) r)))))
+                        [s]))
+    :else (throw (IllegalArgumentException.))))

--- a/src/varity/vcf_to_hgvs/genome.clj
+++ b/src/varity/vcf_to_hgvs/genome.clj
@@ -1,0 +1,42 @@
+(ns varity.vcf-to-hgvs.genome
+  (:require [clojure.pprint :as pp]
+            [clojure.string :as string]
+            [cljam.io.sequence :as cseq]
+            [varity.vcf-to-hgvs.common :as common]))
+
+(defn- sequence-pstring
+  [seq* start end {:keys [pos ref alt]}]
+  (let [[ref-up _ ref-down] (common/split-string-at seq*
+                                                    [(- pos start)
+                                                     (+ (- pos start) (count ref))])
+        nmut (max (count ref) (count alt))
+        ticks (->> (iterate #(+ % 10) (inc (- start (mod start 10))))
+                   (take-while #(<= % end))
+                   (remove #(< % start)))
+        tick-intervals (conj
+                        (->> ticks
+                             (map #(+ % (if (< pos %) (max 0 (- (count alt) (count ref))) 0)))
+                             (map #(- % start))
+                             (partition 2 1)
+                             (mapv #(- (second %) (first %))))
+                        0)]
+    (string/join
+     \newline
+     [(apply pp/cl-format nil
+             (apply str "~V@T" (repeat (count ticks) "~VA"))
+             (- (first ticks) start) (interleave tick-intervals ticks))
+      (pp/cl-format nil "~A~VA~A" ref-up nmut ref ref-down)
+      (pp/cl-format nil "~A~VA~A" ref-up nmut alt ref-down)
+      (pp/cl-format nil "~V@T~V@{~A~:*~}" (- pos start) nmut "^")])))
+
+(defn debug-string
+  [{:keys [pos ref] :as var} seq-rdr rg]
+  (let [start (max 1 (- pos 20))
+        end (+ pos (count ref) 19)
+        seq* (cseq/read-sequence seq-rdr {:chr (:chr rg), :start start, :end end})
+        [ticks refs alts muts] (string/split-lines
+                                (sequence-pstring seq* start end var))]
+    (string/join \newline [(str "         " ticks)
+                           (str "    ref: " refs)
+                           (str "    alt: " alts)
+                           (str "         " muts)])))

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -11,16 +11,6 @@
             [varity.ref-gene :as rg]
             [varity.vcf-to-hgvs.common :refer [diff-bases] :as common]))
 
-(defn- split-string-at [s x]
-  (cond
-    (integer? x) [(subs s 0 x) (subs s x)]
-    (sequential? x) (let [[n & r] x]
-                      (if n
-                        (let [[s1 s2] (split-string-at s n)]
-                          (vec (cons s1 (split-string-at s2 (map #(- % n) r)))))
-                        [s]))
-    :else (throw (IllegalArgumentException.))))
-
 (defn- alt-sequence
   "Returns sequence a variant applied."
   [ref-seq seq-start pos ref alt]
@@ -141,7 +131,7 @@
     alt-prot-seq
     (let [s (subs alt-tx-prot-seq
                   ini-offset)
-          [s-head s-tail] (split-string-at s (count alt-prot-seq))]
+          [s-head s-tail] (common/split-string-at s (count alt-prot-seq))]
       (if-let [end (string/index-of s-tail \*)]
         (str s-head
              (subs s-tail 0 (inc end)))
@@ -165,13 +155,13 @@
           base-ppos (case strand
                       :forward ppos
                       :reverse (protein-position (+ pos (count ref) -1) rg))
-          [_ pref ref-prot-rest] (split-string-at
+          [_ pref ref-prot-rest] (common/split-string-at
                                   ref-prot-seq
                                   [(dec base-ppos)
                                    (case strand
                                      :forward (protein-position (+ pos (count ref) -1) rg)
                                      :reverse ppos)])
-          [_ palt alt-prot-rest] (split-string-at
+          [_ palt alt-prot-rest] (common/split-string-at
                                   alt-prot-seq*
                                   [(min (dec base-ppos) (count alt-prot-seq*))
                                    (min (case strand

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -12,16 +12,7 @@
             [varity.ref-gene :as rg]
             [varity.vcf-to-hgvs.common :refer [diff-bases] :as common]))
 
-(defn- alt-sequence
-  "Returns sequence a variant applied."
-  [ref-seq seq-start pos ref alt]
-  (let [pos* (inc (- pos seq-start))]
-    (str (subs ref-seq 0 (max 0 (dec pos*)))
-         alt
-         (subs ref-seq (min (count ref-seq)
-                            (+ (dec pos*) (count ref)))))))
-
-(defn- alt-exon-ranges
+(defn alt-exon-ranges
   "Returns exon ranges a variant applied."
   [exon-ranges pos ref alt]
   (let [nref (count ref)
@@ -51,7 +42,7 @@
                    :same [s e])))
          vec)))
 
-(defn- exon-sequence
+(defn exon-sequence
   "Extracts bases in exon from supplied sequence, returning the sequence of
   bases as string."
   ([sequence* start exon-ranges]
@@ -81,7 +72,7 @@
   [seq-rdr rg pos ref alt]
   (let [{:keys [chr tx-start tx-end cds-start cds-end exon-ranges strand]} rg
         ref-seq (cseq/read-sequence seq-rdr {:chr chr, :start cds-start, :end cds-end})
-        alt-seq (alt-sequence ref-seq cds-start pos ref alt)
+        alt-seq (common/alt-sequence ref-seq cds-start pos ref alt)
         alt-exon-ranges* (alt-exon-ranges exon-ranges pos ref alt)
         ref-exon-seq1 (exon-sequence ref-seq cds-start exon-ranges)
         ref-up-exon-seq1 (->> (read-exon-sequence seq-rdr chr tx-start (dec cds-start) exon-ranges)

--- a/test/varity/vcf_to_hgvs/cdna_test.clj
+++ b/test/varity/vcf_to_hgvs/cdna_test.clj
@@ -1,0 +1,29 @@
+(ns varity.vcf-to-hgvs.cdna-test
+  (:require [clojure.string :as string]
+            [clojure.test :refer :all]
+            [varity.vcf-to-hgvs.cdna :as cdna]))
+
+(deftest sequence-pstring-test
+  (are [ref-seq alt-seq start end m rg e]
+      (= (#'cdna/sequence-pstring ref-seq alt-seq start end m rg) e)
+    ;; NM_005228:c.2573T>G
+    "CAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGGA"
+    "CAAGATCACAGATTTTGGGCGGGCCAAACTGCTGGGTGCGGA"
+    55191802 55191843 {:pos 55191822, :ref "T", :alt "G"}
+    {:strand :forward, :tx-start 55019032, :tx-end 55207338, :cds-start 55019278, :cds-end 55205617,
+     :exon-ranges [[55019032 55019365] [55142286 55142437] [55143305 55143488] [55146606 55146740] [55151294 55151362] [55152546 55152664] [55154011 55154152] [55155830 55155946] [55156533 55156659] [55156759 55156832] [55157663 55157753] [55160139 55160338] [55161499 55161631] [55163733 55163823] [55165280 55165437] [55171175 55171213] [55172983 55173124] [55173921 55174043] [55174722 55174820] [55181293 55181478] [55191719 55191874]]}
+    (string/join \newline ["         2562      2572      2582      2592"
+                           "CAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGGA"
+                           "CAAGATCACAGATTTTGGGCGGGCCAAACTGCTGGGTGCGGA"
+                           "                    ^"])
+
+    ;; NM_004369:c.6063+6[9]
+    "ctggtctgtgtataaagacataaaaaaaactcacAAGCTGCT"
+    "ctggtctgtgtataaagacataaaaaaaaactcacAAGCTGCT"
+    237363219 237363260 {:pos 237363239, :ref "t", :alt "ta"}
+    {:strand :reverse, :tx-start 237324012, :tx-end 237414207, :cds-start 237324774, :cds-end 237396817,
+     :exon-ranges [[237363253 237363398] [237364350 237364428] [237365698 237366035] [237366687 237367286] [237368563 237369177] [237371732 237372337] [237374412 237375020] [237376772 237377344] [237378636 237379235] [237380915 237381499] [237387582 237388184] [237394587 237395204] [237396727 237396847] [237413953 237414207]]}
+    (string/join \newline ["         6063+2    6063+12  6063+22   6063+32"
+                           "AGCAGCTTgtgagtttttttt atgtctttatacacagaccag"
+                           "AGCAGCTTgtgagtttttttttatgtctttatacacagaccag"
+                           "                    ^^"])))

--- a/test/varity/vcf_to_hgvs/common_test.clj
+++ b/test/varity/vcf_to_hgvs/common_test.clj
@@ -77,3 +77,9 @@
       (are [v rg] (map? (common/normalize-variant v seq-rdr rg))
         {:chr "chr17", :pos 43125270, :ref "CCTTTACCCAGAGCAGAGGGTGAAGGCCTCCTGAGCGCAGGGGCCCAGTTATCTGAGAAACCCCACAGCCTGTCCCCCGTCCAGGAAGTCTCAGCGAGCTCACGCCGCGCAGTCGCAGTTTTAATTTATCTGTAATTCCCGCGCTTTTCCGTTGCCACGGAAACCAAGGGGCTACCGCTAAG", :alt "C"}
         {:tx-start 43044295, :strand :reverse}))))
+
+(deftest alt-sequence-test
+  (are [st p r a e] (= (common/alt-sequence "ACGTACGTACGT" st p r a) e)
+    5 8 "T" "A" "ACGAACGTACGT"
+    5 8 "T" "TT" "ACGTTACGTACGT"
+    5 8 "TA" "T" "ACGTCGTACGT"))

--- a/test/varity/vcf_to_hgvs/genome_test.clj
+++ b/test/varity/vcf_to_hgvs/genome_test.clj
@@ -1,0 +1,34 @@
+(ns varity.vcf-to-hgvs.genome-test
+  (:require [clojure.string :as string]
+            [clojure.test :refer :all]
+            [varity.vcf-to-hgvs.genome :as genome]))
+
+(deftest sequence-pstring-test
+  (are [seq* start end m e] (= (#'genome/sequence-pstring seq* start end m) e)
+    "CAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGG"
+    2 42 {:pos 22, :ref "T", :alt "G"}
+    (string/join \newline ["         11        21        31        41"
+                           "CAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGG"
+                           "CAAGATCACAGATTTTGGGCGGGCCAAACTGCTGGGTGCGG"
+                           "                    ^"])
+
+    "CAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGG"
+    2 42 {:pos 22, :ref "T", :alt "TCC"}
+    (string/join \newline ["         11        21          31        41"
+                           "CAAGATCACAGATTTTGGGCT  GGCCAAACTGCTGGGTGCGG"
+                           "CAAGATCACAGATTTTGGGCTCCGGCCAAACTGCTGGGTGCGG"
+                           "                    ^^^"])
+
+    "CAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGG"
+    2 42 {:pos 22, :ref "TGG", :alt "T"}
+    (string/join \newline ["         11        21        31        41"
+                           "CAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGG"
+                           "CAAGATCACAGATTTTGGGCT  CCAAACTGCTGGGTGCGG"
+                           "                    ^^^"])
+
+    "TCAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCG"
+    1 41 {:pos 21, :ref "C", :alt "A"}
+    (string/join \newline ["1         11        21        31        41"
+                           "TCAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCG"
+                           "TCAAGATCACAGATTTTGGGATGGCCAAACTGCTGGGTGCG"
+                           "                    ^"])))

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -3,12 +3,6 @@
             [clojure.test :refer :all]
             [varity.vcf-to-hgvs.protein :as prot]))
 
-(deftest alt-sequence-test
-  (are [st p r a e] (= (#'prot/alt-sequence "ACGTACGTACGT" st p r a) e)
-    5 8 "T" "A" "ACGAACGTACGT"
-    5 8 "T" "TT" "ACGTTACGTACGT"
-    5 8 "TA" "T" "ACGTCGTACGT"))
-
 (deftest alt-exon-ranges-test
   ;; 1 [2 3 4] 5 6 7 [8 9 10 11] 12 13 14 15
   (are [p r a e] (= (#'prot/alt-exon-ranges [[2 4] [8 11]] p r a) e)


### PR DESCRIPTION
`varity.vcf-to-hgvs/vcf-variant->hgvs` prints debug information when `{:verbose? true}` option is supplied. That info is useful for further development.

```clj
(require '[clj-hgvs.core :as hgvs]
         '[varity.vcf-to-hgvs :as v2h])

(->> (v2h/vcf-variant->hgvs {:chr "chr7", :pos 55191822, :ref "T", :alt "G"}
                            "path/to/hg38.fa" "path/to/refGene.txt.gz"
                            {:verbose? true})
     (map #(-> % (update :cdna hgvs/format) (update :protein hgvs/format))))
;;  variant: {:chr "chr7", :pos 55191822, :ref "T", :alt "G"}
;; ref-gene: {:name "NM_005228", :name2 "EGFR", :strand :forward}
;;
;;                   55191811  55191821  55191831  55191841
;;     ref: CAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGG
;;     alt: CAAGATCACAGATTTTGGGCGGGCCAAACTGCTGGGTGCGG
;;                              ^
;;
;;                   2562      2572      2582      2592
;;   c.ref: CAAGATCACAGATTTTGGGCTGGCCAAACTGCTGGGTGCGGA
;;   c.alt: CAAGATCACAGATTTTGGGCGGGCCAAACTGCTGGGTGCGGA
;;                              ^
;;
;;             841       851       861       871
;;   p.ref: LAARNVLVKTPQHVKITDFGLAKLLGAEEKEYHAEGGKVPI
;;   p.alt: LAARNVLVKTPQHVKITDFGRAKLLGAEEKEYHAEGGKVPI
;;                              ^
;;
;;=> ({:cdna "NM_005228:c.2573T>G", :protein "p.Leu858Arg"})
```

I confirmed `lein test :all` passed.