### PR TITLE
Use ex-info for varity specific exception

### DIFF
--- a/src/varity/hgvs_to_vcf.clj
+++ b/src/varity/hgvs_to_vcf.clj
@@ -60,7 +60,8 @@
                (rg/ref-genes rs rgidx)
                (if-not (string/blank? gene)
                  (rg/ref-genes gene rgidx)
-                 (throw (IllegalArgumentException. "Transcript (NM_, NR_) or gene must be supplied"))))]
+                 (throw (ex-info "Transcript (NM_, NR_) or gene must be supplied."
+                                 {:type ::ref-gene-clue-not-found}))))]
      (convert hgvs seq-rdr rgs))))
 
 (defmethod hgvs->vcf-variants :ref-gene-entity

--- a/src/varity/hgvs_to_vcf/protein.clj
+++ b/src/varity/hgvs_to_vcf/protein.clj
@@ -45,7 +45,7 @@
                                          (= strand :reverse) util-seq/revcomp)})))
                             (remove nil?))))
                (flatten)))))
-    (throw (IllegalArgumentException. "Unsupported mutation"))))
+    (throw (ex-info "Unsupported mutation" {:type ::unsupported-mutation}))))
 
 (defn ->vcf-variants
   [hgvs seq-rdr rg]

--- a/src/varity/vcf_to_hgvs.clj
+++ b/src/varity/vcf_to_hgvs.clj
@@ -112,7 +112,9 @@
                     (print-debug-info m seq-rdr rg))
                   (cdna/->hgvs m seq-rdr rg)))
            distinct)
-      (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos))))))
+      (throw (ex-info "ref is not found on the position."
+                      {:type ::invalid-ref
+                       :variant {:chr chr, :pos pos, :ref ref, :alt alt}})))))
 
 (defmethod vcf-variant->cdna-hgvs :ref-gene-entity
   [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg} & [options]]
@@ -122,7 +124,9 @@
       (when (:verbose? options)
         (print-debug-info nv seq-rdr rg))
       (cdna/->hgvs (assoc nv :rg rg) seq-rdr rg))
-    (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos)))))
+    (throw (ex-info "ref is not found on the position."
+                    {:type ::invalid-ref
+                     :variant {:chr chr, :pos pos, :ref ref, :alt alt}}))))
 
 ;;; -> protein HGVS
 
@@ -168,7 +172,9 @@
                      (print-debug-info m seq-rdr rg))
                    (prot/->hgvs m seq-rdr rg)))
            distinct)
-      (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos))))))
+      (throw (ex-info "ref is not found on the position."
+                      {:type ::invalid-ref
+                       :variant {:chr chr, :pos pos, :ref ref, :alt alt}})))))
 
 (defmethod vcf-variant->protein-hgvs :ref-gene-entity
   [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg} & [options]]
@@ -179,7 +185,9 @@
         (when (:verbose? options)
           (print-debug-info nv seq-rdr rg))
         (prot/->hgvs (assoc nv :rg rg) seq-rdr rg)))
-    (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos)))))
+    (throw (ex-info "ref is not found on the position."
+                    {:type ::invalid-ref
+                     :variant {:chr chr, :pos pos, :ref ref, :alt alt}}))))
 
 ;;; -> Multiple HGVS
 
@@ -229,7 +237,9 @@
                    :protein (if (cds-affected? m rg)
                               (prot/->hgvs m seq-rdr rg))}))
            distinct)
-      (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos))))))
+      (throw (ex-info "ref is not found on the position."
+                      {:type ::invalid-ref
+                       :variant {:chr chr, :pos pos, :ref ref, :alt alt}})))))
 
 (defmethod vcf-variant->hgvs :ref-gene-entity
   [{:keys [pos ref alt]} seq-rdr {:keys [chr] :as rg} & options]
@@ -242,4 +252,6 @@
       {:cdna (cdna/->hgvs nv seq-rdr rg)
        :protein (if (cds-affected? nv rg)
                   (prot/->hgvs nv seq-rdr rg))})
-    (throw (Exception. (format "\"%s\" is not found on %s:%d" ref chr pos)))))
+    (throw (ex-info "ref is not found on the position."
+                    {:type ::invalid-ref
+                     :variant {:chr chr, :pos pos, :ref ref, :alt alt}}))))

--- a/src/varity/vcf_to_hgvs/cdna.clj
+++ b/src/varity/vcf_to_hgvs/cdna.clj
@@ -69,8 +69,8 @@
                        (and (= ref-repeat 1) (= ins-repeat 1)) :duplication
                        (or (> ref-repeat 1) (> ins-repeat 1)) :repeated-seqs)
         (and (zero? nrefo) (pos? nalto)) :insertion
-        :else (throw (IllegalArgumentException. "Unsupported variant"))))
-    (throw (IllegalArgumentException. "Unsupported variant"))))
+        :else (throw (ex-info "Unsupported variant" {:type ::unsupported-variant}))))
+    (throw (ex-info "Unsupported variant" {:type ::unsupported-variant}))))
 
 (defn- dna-substitution
   [rg pos ref alt]

--- a/src/varity/vcf_to_hgvs/common.clj
+++ b/src/varity/vcf_to_hgvs/common.clj
@@ -54,7 +54,11 @@
              count
              dec
              (* step))))
-    (throw (Exception. (str "\"" bases "\" is not found on " pos " th position")))))
+    (throw (ex-info "The bases is not found on the position."
+                    {:type ::invalid-bases
+                     :sequence seq*
+                     :position pos
+                     :bases bases}))))
 
 ;; seq*        pos bases
 ;; MVSTSTHQ... 5   ST    => 2
@@ -74,7 +78,11 @@
              (take-while #(= (apply str %) rbases))
              count
              tweak)))
-    (throw (Exception. (str "\"" bases "\" is not found on " pos " th position")))))
+    (throw (ex-info "The bases is not found on the position."
+                    {:type ::invalid-bases
+                     :sequence seq*
+                     :position pos
+                     :bases bases}))))
 
 ;; ...CAGTC... 8 AGT => ["AGT" 1 1]
 ;; ...CAGTC... 8 AGTAGT => ["AGT" 1 2]
@@ -201,4 +209,5 @@
                         (let [[s1 s2] (split-string-at s n)]
                           (vec (cons s1 (split-string-at s2 (map #(- % n) r)))))
                         [s]))
-    :else (throw (IllegalArgumentException.))))
+    :else (throw (IllegalArgumentException.
+                  "Splitting position should be an integer or list."))))

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -184,7 +184,7 @@
                              (and (= ref-repeat 1) (= ins-repeat 1)) :duplication
                              (or (> ref-repeat 1) (> ins-repeat 1)) :repeated-seqs)
               (and (zero? nprefo) (pos? npalto)) :insertion
-              :else (throw (IllegalArgumentException. "Unsupported variant")))]
+              :else (throw (ex-info "Unsupported variant" {:type ::unsupported-variant})))]
       {:type (if (= t :fs-ter-substitution) :substitution t)
        :pos base-ppos
        :ref (if (= t :fs-ter-substitution)


### PR DESCRIPTION
`ex-info` is more useful for `catch` side in some cases such as debugging or dispatch.