### PR TITLE
Fix normalization of a variant containing long ref (strand: +)

### DIFF
--- a/src/varity/vcf_to_hgvs/common.clj
+++ b/src/varity/vcf_to_hgvs/common.clj
@@ -150,11 +150,12 @@
                                 :end (+ (:tx-end rg) rg/max-tx-margin)}
                                normalization-read-sequence-step)
        (keep (fn [seq*]
-               (let [nvar (normalize-variant* {:pos 1, :ref ref, :alt alt} seq* :forward)]
-                 (if (<= (dec (:pos nvar)) (- (count seq*) (max (count ref) (count alt))))
-                   (-> nvar
-                       (assoc :chr chr)
-                       (update :pos + pos -1))))))
+               (when (>= (count seq*) (count ref))
+                 (let [nvar (normalize-variant* {:pos 1, :ref ref, :alt alt} seq* :forward)]
+                   (if (<= (dec (:pos nvar)) (- (count seq*) (max (count ref) (count alt))))
+                     (-> nvar
+                         (assoc :chr chr)
+                         (update :pos + pos -1)))))))
        (first)))
 
 (defn- normalize-variant-backward


### PR DESCRIPTION
Variant normalization throws an error when a variant containing long ref (>1000) and a **forward** strand ref-gene are supplied. I overlooked this problem in #17.

```clj
(require '[clj-hgvs.core :as hgvs]
         '[varity.hgvs-to-vcf :as h2v]
         '[varity.vcf-to-hgvs :as v2h])

(def v (first (h2v/hgvs->vcf-variants
               (hgvs/parse "NM_000059:c.67+1154_316+2261del")
               "path/to/hg38.fa" "path/to/refGene.txt.gz")))
;; {:chr "chr13"
;;  :pos 32317680
;;  :ref "AGAAAAGTCTTTTAAGATTGGGTAGAAATGAGCCACTGGAAATTCTAATTTTCA...(3097 chars)"
;;  :alt "A"}

(-> (v2h/vcf-variant->cdna-hgvs v "path/to/hg38.fa" "path/to/refGene.txt.gz")
    first
    hgvs/format)
;; StringIndexOutOfBoundsException begin 1, end 3907, length 1000
;; java.lang.String.checkBoundsBeginEnd (String.java:3107)
```

This PR fixes that problem.

```clj
(-> (v2h/vcf-variant->cdna-hgvs v "path/to/hg38.fa" "path/to/refGene.txt.gz")
    first
    hgvs/format)
;;=> NM_000059:c.67+1154_316+2261del
```

I confirmed `lein test :all` passed.