### PR TITLE
Improve performance of vcf-variant->protein-hgvs

### DIFF
--- a/bench/varity/vcf_to_hgvs_bench.clj
+++ b/bench/varity/vcf_to_hgvs_bench.clj
@@ -1,0 +1,24 @@
+(ns varity.vcf-to-hgvs-bench
+  (:require [cljam.io.sequence :as cseq]
+            [libra.bench :refer :all]
+            [libra.criterium :as c]
+            [varity.ref-gene :as rg]
+            [varity.vcf-to-hgvs :as v2h]
+            [varity.t-common :refer :all]))
+
+(def variants
+  [{:chr "chr7", :pos 55191822, :ref "T", :alt "G"}
+   {:chr "chr1", :pos 247815239, :ref "AAGG", :alt "A"}
+   {:chr "chr2", :pos 26254257, :ref "G", :alt "GACT"}
+   {:chr "chr3", :pos 122740443, :ref "G", :alt "GAGA"}
+   {:chr "chr2", :pos 47445589, :ref "CTTACTGAT", :alt "CCC"}
+   {:chr "chr1", :pos 11796319, :ref "C", :alt "CGGCGGC"}
+   {:chr "chr1", :pos 69567, :ref "A", :alt "AT"}
+   {:chr "chr2", :pos 189011772, :ref "T", :alt "C"}])
+
+(defbench ^:slow vcf-variant->protein-hgvs-bench
+  (prepare-cavia!)
+  (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
+    (with-open [seq-rdr (cseq/reader test-ref-seq-file)]
+      (is (c/quick-bench (doseq [v variants]
+                           (doall (v2h/vcf-variant->protein-hgvs v seq-rdr rgidx))))))))

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [org.clojure/tools.logging "0.4.1"]
                  [clj-hgvs "0.2.4"]
-                 [cljam "0.6.0"]
+                 [cljam "0.7.0"]
                  [org.apache.commons/commons-compress "1.18"]
                  [proton "0.1.6"]]
   :plugins [[lein-cloverage "1.0.13"]

--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,9 @@
   :deploy-repositories [["snapshots" {:url "https://clojars.org/repo/"
                                       :username [:env/clojars_username :gpg]
                                       :password [:env/clojars_password :gpg]}]]
+  :libra {:bench-selectors {:default (complement :slow)
+                            :slow :slow
+                            :all (constantly true)}}
   :codox {:namespaces [#"^varity\.[\w\-]+$"]
           :output-path "docs"
           :source-uri "https://github.com/chrovis/varity/blob/{version}/{filepath}#L{line}"})

--- a/src/varity/codon.clj
+++ b/src/varity/codon.clj
@@ -101,8 +101,7 @@
 (defn amino-acid-sequence
   "Converts nucleotide sequence into amino acid sequence."
   [s]
-  {:pre [(string? s)]}
-  (->> (partition 3 s)
-       (map #(apply str %))
-       (map codon->amino-acid)
+  (->> (string/upper-case s)
+       (re-seq #".{3}")
+       (map codon-amino-acid-map)
        (apply str)))

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -75,18 +75,11 @@
         alt-seq (common/alt-sequence ref-seq cds-start pos ref alt)
         alt-exon-ranges* (alt-exon-ranges exon-ranges pos ref alt)
         ref-exon-seq1 (exon-sequence ref-seq cds-start exon-ranges)
-        ref-up-exon-seq1 (->> (read-exon-sequence seq-rdr chr tx-start (dec cds-start) exon-ranges)
-                              reverse
-                              (partition 3)
-                              flatten
-                              reverse
-                              (apply str))
-        ref-down-exon-seq1 (->> (read-exon-sequence seq-rdr chr (inc cds-end) tx-end exon-ranges)
-                                reverse
-                                (partition 3)
-                                flatten
-                                reverse
-                                (apply str))
+        ref-up-exon-seq1 (read-exon-sequence seq-rdr chr tx-start (dec cds-start) exon-ranges)
+        ref-up-exon-seq1 (subs ref-up-exon-seq1 (mod (count ref-up-exon-seq1) 3))
+        ref-down-exon-seq1 (read-exon-sequence seq-rdr chr (inc cds-end) tx-end exon-ranges)
+        nref-down-exon-seq1 (count ref-down-exon-seq1)
+        ref-down-exon-seq1 (subs ref-down-exon-seq1 0 (- nref-down-exon-seq1 (mod nref-down-exon-seq1 3)))
         alt-exon-seq1 (exon-sequence alt-seq cds-start alt-exon-ranges*)]
     {:ref-exon-seq ref-exon-seq1
      :ref-prot-seq (codon/amino-acid-sequence (cond-> ref-exon-seq1

--- a/test/varity/codon_test.clj
+++ b/test/varity/codon_test.clj
@@ -27,4 +27,4 @@
     "ATGTCACTGTAA" "MSL*"
     "atgtcactgtaa" "MSL*"
     "" "")
-  (is (thrown? Error (amino-acid-sequence nil))))
+  (is (thrown? Throwable (amino-acid-sequence nil))))


### PR DESCRIPTION
Improves performance of vcf-variant->protein-hgvs by optimizing amino acid conversion and sequence retrieving. That can be checked with libra benchmark code.

before (commit 3ec5ed6):

```console
$ lein libra :only varity.vcf-to-hgvs-bench

Measuring varity.vcf-to-hgvs-bench

vcf-variant->protein-hgvs-bench (vcf_to_hgvs_bench.clj:19)

  time: 97.077914 ms, sd: 113.403155 µs
```

after (commit ac184f7):

```console
$ lein libra :only varity.vcf-to-hgvs-bench

Measuring varity.vcf-to-hgvs-bench

vcf-variant->protein-hgvs-bench (vcf_to_hgvs_bench.clj:19)

  time: 26.393281 ms, sd: 597.575155 ns
```

I confirmed `lein test :all` passed.