### PR TITLE
Update clj-hgvs and proton

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :min-lein-version "2.7.0"
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [clj-hgvs "0.2.4"]
+                 [clj-hgvs "0.3.0"]
                  [cljam "0.7.0"]
                  [org.apache.commons/commons-compress "1.18"]
                  [proton "0.1.6"]]
@@ -20,7 +20,8 @@
                                   [criterium "0.4.4"]
                                   [net.totakke/libra "0.1.1"]]}
              :repl {:source-paths ["bench"]}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
+                                  [clojure-future-spec "1.9.0-beta4"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.0-alpha5"]]}}
   :deploy-repositories [["snapshots" {:url "https://clojars.org/repo/"
                                       :username [:env/clojars_username :gpg]

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [clj-hgvs "0.3.0"]
                  [cljam "0.7.0"]
                  [org.apache.commons/commons-compress "1.18"]
-                 [proton "0.1.6"]]
+                 [proton "0.1.7"]]
   :plugins [[lein-cloverage "1.0.13"]
             [lein-codox "0.10.5"]
             [net.totakke/lein-libra "0.1.2"]]

--- a/src/varity/vcf_to_hgvs/cdna.clj
+++ b/src/varity/vcf_to_hgvs/cdna.clj
@@ -6,6 +6,7 @@
             [clj-hgvs.mutation :as mut]
             [cljam.util.sequence :as util-seq]
             [cljam.io.sequence :as cseq]
+            [proton.string :as pstring]
             [varity.ref-gene :as rg]
             [varity.vcf-to-hgvs.common :refer [diff-bases] :as common]))
 
@@ -208,12 +209,12 @@
                :reverse (- end pos))
         ref-seq (cond-> ref-seq (= (:strand rg) :reverse) util-seq/revcomp)
         alt-seq (cond-> alt-seq (= (:strand rg) :reverse) util-seq/revcomp)
-        [ref-up ref ref-down] (common/split-string-at ref-seq
-                                                      [pos*
-                                                       (+ pos* (count ref))])
-        [alt-up alt alt-down] (common/split-string-at alt-seq
-                                                      [pos*
-                                                       (+ pos* (count alt))])
+        [ref-up ref ref-down] (pstring/split-at ref-seq
+                                                [pos*
+                                                 (+ pos* (count ref))])
+        [alt-up alt alt-down] (pstring/split-at alt-seq
+                                                [pos*
+                                                 (+ pos* (count alt))])
         nmut (max (count ref) (count alt))
         ticks (->> (iterate #(+ % 10) (inc (- start (mod start 10))))
                    (take-while #(<= % end))

--- a/src/varity/vcf_to_hgvs/common.clj
+++ b/src/varity/vcf_to_hgvs/common.clj
@@ -201,14 +201,3 @@
          alt
          (subs ref-seq (min (count ref-seq)
                             (+ (dec pos*) (count ref)))))))
-
-(defn split-string-at [s x]
-  (cond
-    (integer? x) [(subs s 0 x) (subs s x)]
-    (sequential? x) (let [[n & r] x]
-                      (if n
-                        (let [[s1 s2] (split-string-at s n)]
-                          (vec (cons s1 (split-string-at s2 (map #(- % n) r)))))
-                        [s]))
-    :else (throw (IllegalArgumentException.
-                  "Splitting position should be an integer or list."))))

--- a/src/varity/vcf_to_hgvs/genome.clj
+++ b/src/varity/vcf_to_hgvs/genome.clj
@@ -2,13 +2,13 @@
   (:require [clojure.pprint :as pp]
             [clojure.string :as string]
             [cljam.io.sequence :as cseq]
-            [varity.vcf-to-hgvs.common :as common]))
+            [proton.string :as pstring]))
 
 (defn- sequence-pstring
   [seq* start end {:keys [pos ref alt]}]
-  (let [[ref-up _ ref-down] (common/split-string-at seq*
-                                                    [(- pos start)
-                                                     (+ (- pos start) (count ref))])
+  (let [[ref-up _ ref-down] (pstring/split-at seq*
+                                              [(- pos start)
+                                               (+ (- pos start) (count ref))])
         nmut (max (count ref) (count alt))
         ticks (->> (iterate #(+ % 10) (inc (- start (mod start 10))))
                    (take-while #(<= % end))

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -8,6 +8,7 @@
             [cljam.io.sequence :as cseq]
             [cljam.util.sequence :as util-seq]
             [proton.core :as proton]
+            [proton.string :as pstring]
             [varity.codon :as codon]
             [varity.ref-gene :as rg]
             [varity.vcf-to-hgvs.common :refer [diff-bases] :as common]))
@@ -116,7 +117,7 @@
     alt-prot-seq
     (let [s (subs alt-tx-prot-seq
                   ini-offset)
-          [s-head s-tail] (common/split-string-at s (count alt-prot-seq))]
+          [s-head s-tail] (pstring/split-at s (count alt-prot-seq))]
       (if-let [end (string/index-of s-tail \*)]
         (str s-head
              (subs s-tail 0 (inc end)))
@@ -140,13 +141,13 @@
           base-ppos (case strand
                       :forward ppos
                       :reverse (protein-position (+ pos (count ref) -1) rg))
-          [_ pref ref-prot-rest] (common/split-string-at
+          [_ pref ref-prot-rest] (pstring/split-at
                                   ref-prot-seq
                                   [(dec base-ppos)
                                    (case strand
                                      :forward (protein-position (+ pos (count ref) -1) rg)
                                      :reverse ppos)])
-          [_ palt alt-prot-rest] (common/split-string-at
+          [_ palt alt-prot-rest] (pstring/split-at
                                   alt-prot-seq*
                                   [(min (dec base-ppos) (count alt-prot-seq*))
                                    (min (case strand
@@ -324,14 +325,14 @@
 
 (defn- prot-seq-pstring
   [pref-seq palt-seq start end {:keys [ppos pref palt]}]
-  (let [[pref-up _ pref-down] (common/split-string-at pref-seq
-                                                      [(- ppos start)
-                                                       (min (count pref-seq)
-                                                            (+ (- ppos start) (count pref)))])
-        [palt-up _ palt-down] (common/split-string-at palt-seq
-                                                      [(- ppos start)
-                                                       (min (count palt-seq)
-                                                            (+ (- ppos start) (count palt)))])
+  (let [[pref-up _ pref-down] (pstring/split-at pref-seq
+                                                [(- ppos start)
+                                                 (min (count pref-seq)
+                                                      (+ (- ppos start) (count pref)))])
+        [palt-up _ palt-down] (pstring/split-at palt-seq
+                                                [(- ppos start)
+                                                 (min (count palt-seq)
+                                                      (+ (- ppos start) (count palt)))])
         frame-shift? (if (<= (count pref) (count palt))
                        (or (empty? palt-down)
                            (nil? (string/index-of pref-down palt-down)))

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -135,6 +135,7 @@
 (defn- vcf-variant->protein-hgvs-texts
   [variant seq-rdr rgidx]
   (map #(hgvs/format % {:amino-acid-format :short
+                        :show-ter-site? true
                         :ter-format :short})
        (vcf-variant->protein-hgvs variant seq-rdr rgidx)))
 


### PR DESCRIPTION
Update of clj-hgvs and proton does not affect varity function, but it contains implicit breaking changes.

clj-hgvs 0.3.0 requires clojure 1.9+ because it uses clojure.spec for HGVS validation. To use varity with clojure 1.8, you must include a dependency on [clojure-future-spec](https://github.com/tonsky/clojure-future-spec).

Besides, in clj-hgvs 0.3.0, termination codon site of protein frameshift is not printed by default. If you want to display it, you must supply `:show-ter-site? true` option to `clj-hgvs.core/format`.

`proton.string/split-at` was implemented in proton 0.1.7, so I replaced the same function in varity with it.

I confirmed `lein test :all` passed.