### PR TITLE
Fix pos of hgvs->vcf-variants for genes on reverse strand

### DIFF
--- a/src/varity/hgvs_to_vcf/protein.clj
+++ b/src/varity/hgvs_to_vcf/protein.clj
@@ -30,10 +30,11 @@
                               (apply str))
               ref-codon (cond-> ref-codon1 (= strand :reverse) util-seq/revcomp)
               palt (mut/->short-amino-acid (:alt mut*))
-              codon-cands (codon/amino-acid->codons palt)]
+              codon-cands (codon/amino-acid->codons palt)
+              pos-cands* (cond-> pos-cands (= strand :reverse) reverse)]
           (->> codon-cands
                (keep (fn [codon*]
-                       (->> pos-cands
+                       (->> pos-cands*
                             (map-indexed
                              (fn [idx pos]
                                (if (one-character-substituted? ref-codon codon* idx)

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -89,6 +89,8 @@
           (= (hgvs->vcf-variants (hgvs/parse hgvs*) gene test-ref-seq-file rgidx) e)
         "p.L858R" "EGFR" '({:chr "chr7", :pos 55191822, :ref "T", :alt "G"}) ; cf. rs121434568
         "p.A222V" "MTHFR" '({:chr "chr1", :pos 11796321, :ref "G", :alt "A"}) ; cf. rs1801133
+        "p.Q61K" "NRAS" '({:chr "chr1", :pos 114713909, :ref "G", :alt "T"}) ; cf. rs121913254
+        "p.Q61K" "KRAS" '({:chr "chr12", :pos 25227343, :ref "G", :alt "T"}) ; cf. rs121913238
         )))
   (cavia-testing "protein HGVS with gene to possible vcf variants with cDNA HGVS"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]


### PR DESCRIPTION
### summary
This PR fixes a problem that hgvs->vcf converted `:pos` may be incorrect when the target gene is on the reverse strand.

### problem
For example, [KRAS p.Q61K](https://www.ncbi.nlm.nih.gov/clinvar/variation/177777/) is reported to be located at chr12:25227343 (hg38)

#### reference sequence

```clojure
(cseq/read-sequence seq-rdr {:chr "chr12", :start 25227340, :end 25227350})
;; => "CTTGACCTGCT"
;;     01234567890
```
- 25227341 `T`
- 25227343 `G`

#### master

```clojure
(h2v/hgvs->vcf-variants (hgvs/parse "p.Q61K") "KRAS" seq-rdr rg-idx)
;; => ({:chr "chr12", :pos 25227341, :ref "G", :alt "T"})
```

### cause

This was caused by aligning reverse-complement nucleotide sequences and ascending genomic coordinate sequences. Reversing the genomic coordinates will fix the problem.

#### PR

```clojure
(h2v/hgvs->vcf-variants (hgvs/parse "p.Q61K") "KRAS" seq-rdr rg-idx)
;; => ({:chr "chr12", :pos 25227343, :ref "G", :alt "T"})
```

### checks
- `lein test :all` :ok:
- `lein check` :ok:
- `lein eastwood` :ok:
- `lein cljfmt check` :ok:
- `lein bikeshed` :ok: