### PR TITLE
Remove incorrect VCF variants from protein HGVS to VCF variants conversion results

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                    :all (constantly true)}
   :profiles {:dev {:dependencies [[cavia "0.5.1"]
                                   [codox-theme-rdash "0.1.2"]
-                                  [criterium "0.4.4"]
+                                  [criterium "0.4.5"]
                                   [net.totakke/libra "0.1.1"]]}
              :repl {:source-paths ["bench"]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [org.clojure/tools.logging "0.4.1"]
                  [clj-hgvs "0.3.0"]
-                 [cljam "0.7.0"]
+                 [cljam "0.7.1"]
                  [org.apache.commons/commons-compress "1.18"]
                  [proton "0.1.7"]]
   :plugins [[lein-cloverage "1.0.13"]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :min-lein-version "2.7.0"
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [clj-hgvs "0.3.0"]
+                 [clj-hgvs "0.3.1"]
                  [cljam "0.7.1"]
                  [org.apache.commons/commons-compress "1.18"]
                  [proton "0.1.7"]]

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [clj-hgvs "0.3.1"]
                  [cljam "0.7.1"]
                  [org.apache.commons/commons-compress "1.18"]
-                 [proton "0.1.7"]]
+                 [proton "0.1.8"]]
   :plugins [[lein-cloverage "1.0.13"]
             [lein-codox "0.10.5"]
             [net.totakke/lein-libra "0.1.2"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject varity "0.5.0"
+(defproject varity "0.5.1-SNAPSHOT"
   :description "Variant translation library for Clojure"
   :url "https://github.com/chrovis/varity"
   :license {:name "Apache License, Version 2.0"

--- a/src/varity/hgvs_to_vcf/protein.clj
+++ b/src/varity/hgvs_to_vcf/protein.clj
@@ -26,28 +26,33 @@
     (let [pos-cands (pos-candidates (:coord mut*) rg)]
       (if (seq pos-cands)
         (let [ref-codon1 (->> pos-cands
-                              (map #(cseq/read-sequence seq-rdr {:chr chr, :start %, :end %}))
+                              (map #(cseq/read-sequence
+                                     seq-rdr
+                                     {:chr chr, :start %, :end %}))
                               (apply str))
-              ref-codon (cond-> ref-codon1 (= strand :reverse) util-seq/revcomp)
+              reverse? (= strand :reverse)
+              ref-codon (cond-> ref-codon1 reverse? util-seq/revcomp)
               ref-aa (codon/codon->amino-acid ref-codon)
               mut-ref-aa (mut/->short-amino-acid (:ref mut*))]
           (when (= mut-ref-aa ref-aa)
             (let [palt (mut/->short-amino-acid (:alt mut*))
                   codon-cands (codon/amino-acid->codons palt)
-                  pos-cands* (cond-> pos-cands (= strand :reverse) reverse)]
+                  pos-cands* (cond-> pos-cands reverse? reverse)]
               (->> codon-cands
-                   (keep (fn [codon*]
-                           (->> pos-cands*
-                                (map-indexed
-                                 (fn [idx pos]
-                                   (if (one-character-substituted? ref-codon codon* idx)
-                                     {:chr chr
-                                      :pos pos
-                                      :ref (cond-> (str (nth ref-codon idx))
-                                             (= strand :reverse) util-seq/revcomp)
-                                      :alt (cond-> (str (nth codon* idx))
-                                             (= strand :reverse) util-seq/revcomp)})))
-                                (remove nil?))))
+                   (keep
+                    (fn [codon*]
+                      (->> pos-cands*
+                           (map-indexed
+                            (fn [idx pos]
+                              (if (one-character-substituted?
+                                   ref-codon codon* idx)
+                                {:chr chr
+                                 :pos pos
+                                 :ref (cond-> (str (nth ref-codon idx))
+                                        reverse? util-seq/revcomp)
+                                 :alt (cond-> (str (nth codon* idx))
+                                        reverse? util-seq/revcomp)})))
+                           (remove nil?))))
                    (flatten)))))))
     (throw (ex-info "Unsupported mutation" {:type ::unsupported-mutation}))))
 
@@ -61,32 +66,43 @@
     (let [pos-cands (pos-candidates (:coord mut*) rg)]
       (if (seq pos-cands)
         (let [ref-codon1 (->> pos-cands
-                              (map #(cseq/read-sequence seq-rdr {:chr chr, :start %, :end %}))
+                              (map #(cseq/read-sequence
+                                     seq-rdr
+                                     {:chr chr, :start %, :end %}))
                               (apply str))
-              ref-codon (cond-> ref-codon1 (= strand :reverse) util-seq/revcomp)
+              reverse? (= strand :reverse)
+              ref-codon (cond-> ref-codon1 reverse? util-seq/revcomp)
               ref-aa (codon/codon->amino-acid ref-codon)
               mut-ref-aa (mut/->short-amino-acid (:ref mut*))]
           (when (= mut-ref-aa ref-aa)
             (let [palt (mut/->short-amino-acid (:alt mut*))
                   codon-cands (codon/amino-acid->codons palt)
-                  pos-cands (cond-> pos-cands (= strand :reverse) reverse)]
+                  pos-cands (cond-> pos-cands reverse? reverse)]
               (->> codon-cands
-                   (keep (fn [codon*]
-                           (->> pos-cands
-                                (map-indexed
-                                 (fn [idx pos]
-                                   (if (one-character-substituted? ref-codon codon* idx)
-                                     (let [ref (str (nth ref-codon idx))
-                                           alt (str (nth codon* idx))]
-                                       {:vcf {:chr chr
-                                              :pos pos
-                                              :ref (cond-> ref (= strand :reverse) util-seq/revcomp)
-                                              :alt (cond-> alt (= strand :reverse) util-seq/revcomp)}
-                                        :cdna (hgvs/hgvs (:name rg) :cdna (mut/dna-substitution (rg/cds-coord pos rg)
-                                                                                                ref
-                                                                                                (if (= ref alt) "=" ">")
-                                                                                                alt))}))))
-                                (remove nil?))))
+                   (keep
+                    (fn [codon*]
+                      (->> pos-cands
+                           (map-indexed
+                            (fn [idx pos]
+                              (if (one-character-substituted?
+                                   ref-codon codon* idx)
+                                (let [ref (str (nth ref-codon idx))
+                                      alt (str (nth codon* idx))]
+                                  {:vcf {:chr chr
+                                         :pos pos
+                                         :ref (cond-> ref
+                                                reverse? util-seq/revcomp)
+                                         :alt (cond-> alt
+                                                reverse? util-seq/revcomp)}
+                                   :cdna (hgvs/hgvs
+                                          (:name rg)
+                                          :cdna
+                                          (mut/dna-substitution
+                                           (rg/cds-coord pos rg)
+                                           ref
+                                           (if (= ref alt) "=" ">")
+                                           alt))}))))
+                           (remove nil?))))
                    (flatten)))))))
     (throw (IllegalArgumentException. "Unsupported mutation"))))
 

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -1,11 +1,11 @@
 (ns varity.hgvs-to-vcf-test
   (:require [clojure.test :refer :all]
             [clj-hgvs.core :as hgvs]
+            [cljam.io.sequence :as cseq]
             [varity.ref-gene :as rg]
             [varity.hgvs-to-vcf :refer :all]
             [varity.t-common :refer :all]
-            [varity.vcf-to-hgvs :as v2h]
-            [cljam.io.sequence :as cseq]))
+            [varity.vcf-to-hgvs :as v2h]))
 
 (defslowtest hgvs->vcf-variants-test
   (cavia-testing "cDNA HGVS to vcf variants"
@@ -103,7 +103,7 @@
                             :cdna ~(hgvs/parse "NM_005228:c.2369C>T")})
         "p.L1196M" "ALK" `({:vcf {:chr "chr2", :pos 29220765, :ref "G", :alt "T"} ; cf. rs1057519784
                             :cdna ~(hgvs/parse "NM_004304:c.3586C>A")})
-        "p.K652T" "FGFR3" `({:vcf {:chr "chr4", :pos 1806163, :ref "A", :alt "C"},
+        "p.K652T" "FGFR3" `({:vcf {:chr "chr4", :pos 1806163, :ref "A", :alt "C"},; cf. rs121913105
                              :cdna ~(hgvs/parse "NM_001163213:c.1955A>C")})))))
 
 (defslowtest hgvs->vcf->hgvs-test
@@ -119,10 +119,9 @@
                      (hgvs/parse ?protein-hgvs) nm r rgidx)))
                  (map
                   (fn [{:keys [vcf] {:keys [transcript]} :cdna :as v}]
-                    ;; make a rgidx with only one transcript
                     (let [[hgvs & xs] (->> rgidx
                                            (rg/ref-genes transcript)
-                                           rg/index
+                                           first
                                            (v2h/vcf-variant->protein-hgvs vcf r))
                           fmt (hgvs/format hgvs {:amino-acid-format :short})]
                       ;; 1 variant & 1 transcript => 1 canonical hgvs

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -119,13 +119,12 @@
                      (hgvs/parse ?protein-hgvs) nm r rgidx)))
                  (map
                   (fn [{:keys [vcf] {:keys [transcript]} :cdna :as v}]
-                    (let [[hgvs & xs] (->> rgidx
-                                           (rg/ref-genes transcript)
-                                           first
-                                           (v2h/vcf-variant->protein-hgvs vcf r))
+                    (let [hgvs (->> rgidx
+                                    (rg/ref-genes transcript)
+                                    first
+                                    (v2h/vcf-variant->protein-hgvs vcf r))
                           fmt (hgvs/format hgvs {:amino-acid-format :short})]
                       ;; 1 variant & 1 transcript => 1 canonical hgvs
-                      (assert (nil? xs))
                       (assoc v :hgvs (assoc hgvs :format fmt)))))
                  (map (comp :format :hgvs))
                  (apply = ?protein-hgvs))

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -3,7 +3,9 @@
             [clj-hgvs.core :as hgvs]
             [varity.ref-gene :as rg]
             [varity.hgvs-to-vcf :refer :all]
-            [varity.t-common :refer :all]))
+            [varity.t-common :refer :all]
+            [varity.vcf-to-hgvs :as v2h]
+            [cljam.io.sequence :as cseq]))
 
 (defslowtest hgvs->vcf-variants-test
   (cavia-testing "cDNA HGVS to vcf variants"
@@ -91,6 +93,7 @@
         "p.A222V" "MTHFR" '({:chr "chr1", :pos 11796321, :ref "G", :alt "A"}) ; cf. rs1801133
         "p.Q61K" "NRAS" '({:chr "chr1", :pos 114713909, :ref "G", :alt "T"}) ; cf. rs121913254
         "p.Q61K" "KRAS" '({:chr "chr12", :pos 25227343, :ref "G", :alt "T"}) ; cf. rs121913238
+        "p.K652T" "FGFR3" '({:chr "chr4", :pos 1806163, :ref "A", :alt "C"}) ; cf. rs121913105
         )))
   (cavia-testing "protein HGVS with gene to possible vcf variants with cDNA HGVS"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
@@ -99,4 +102,32 @@
         "p.T790M" "EGFR" `({:vcf {:chr "chr7", :pos 55181378, :ref "C", :alt "T"} ; cf. rs121434569
                             :cdna ~(hgvs/parse "NM_005228:c.2369C>T")})
         "p.L1196M" "ALK" `({:vcf {:chr "chr2", :pos 29220765, :ref "G", :alt "T"} ; cf. rs1057519784
-                            :cdna ~(hgvs/parse "NM_004304:c.3586C>A")})))))
+                            :cdna ~(hgvs/parse "NM_004304:c.3586C>A")})
+        "p.K652T" "FGFR3" `({:vcf {:chr "chr4", :pos 1806163, :ref "A", :alt "C"},
+                             :cdna ~(hgvs/parse "NM_001163213:c.1955A>C")})))))
+
+(defslowtest hgvs->vcf->hgvs-test
+  (cavia-testing "protein HGVS with gene to possible vcf variants which gives the same protein HGVS"
+    (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
+      (with-open [r (cseq/reader test-ref-seq-file)]
+        (are [?protein-hgvs ?gene-symbol]
+            (->> (map :name (rg/ref-genes ?gene-symbol rgidx))
+                 (mapcat
+                  (fn [nm]
+                    ;; hgvs -> variants with a specific accession number
+                    (protein-hgvs->vcf-variants-with-cdna-hgvs
+                     (hgvs/parse ?protein-hgvs) nm r rgidx)))
+                 (map
+                  (fn [{:keys [vcf] {:keys [transcript]} :cdna :as v}]
+                    ;; make a rgidx with only one transcript
+                    (let [[hgvs & xs] (->> rgidx
+                                           (rg/ref-genes transcript)
+                                           rg/index
+                                           (v2h/vcf-variant->protein-hgvs vcf r))
+                          fmt (hgvs/format hgvs {:amino-acid-format :short})]
+                      ;; 1 variant & 1 transcript => 1 canonical hgvs
+                      (assert (nil? xs))
+                      (assoc v :hgvs (assoc hgvs :format fmt)))))
+                 (map (comp :format :hgvs))
+                 (apply = ?protein-hgvs))
+          "p.K652T" "FGFR3")))))


### PR DESCRIPTION
#### Summary
This PR fixes a bug that `varity.hgvs-to-vcf/hgvs->vcf-variants` and `varity.hgvs-to-vcf/protein-hgvs->vcf-variants-with-cdna-hgvs` returns incorrect VCF-style genomic variants which can't be translated to the original protein HGVS.

#### Problem
When trying to convert `p.K652T` of `FGFR3` to genomic variants,
`varity.hgvs-to-vcf/hgvs->vcf-variants` gives 8 results and `varity.hgvs-to-vcf/protein-hgvs->vcf-variants-with-cdna-hgvs` gives 11 but most of them are incorrect (`p.T652=` and `p.S652T`).

<details>

```clojure
user> (h2v/hgvs->vcf-variants (hgvs/parse "p.K652T") "FGFR3" reader-hg38 rg-idx-hg38)
({:chr "chr4", :pos 1807131, :ref "T", :alt "A"}
 {:chr "chr4", :pos 1806167, :ref "G", :alt "A"}
 {:chr "chr4", :pos 1806167, :ref "G", :alt "C"}
 {:chr "chr4", :pos 1806167, :ref "G", :alt "T"}
 {:chr "chr4", :pos 1806163, :ref "A", :alt "C"}
 {:chr "chr4", :pos 1806170, :ref "C", :alt "A"}
 {:chr "chr4", :pos 1806170, :ref "C", :alt "G"}
 {:chr "chr4", :pos 1806170, :ref "C", :alt "T"})

user> (h2v/protein-hgvs->vcf-variants-with-cdna-hgvs (hgvs/parse "p.K652T") "FGFR3" reader-hg38 rg-idx-hg38)
({:vcf {:chr "chr4", :pos 1807131, :ref "T", :alt "A"},
  :cdna
  {:transcript "NM_022965",
   :kind :cdna,
   :mutation
   {:coord {:position 1954, :offset 0, :region nil},
    :ref "T",
    :type ">",
    :alt "A"}}}
 {:vcf {:chr "chr4", :pos 1806167, :ref "G", :alt "A"},
  :cdna
  {:transcript "NM_001354809",
   :kind :cdna,
   :mutation
   {:coord {:position 1956, :offset 0, :region nil},
    :ref "G",
    :type ">",
    :alt "A"}}}
 {:vcf {:chr "chr4", :pos 1806167, :ref "G", :alt "C"},
  :cdna
  {:transcript "NM_001354809",
   :kind :cdna,
   :mutation
   {:coord {:position 1956, :offset 0, :region nil},
    :ref "G",
    :type ">",
    :alt "C"}}}
 {:vcf {:chr "chr4", :pos 1806167, :ref "G", :alt "T"},
  :cdna
  {:transcript "NM_001354809",
   :kind :cdna,
   :mutation
   {:coord {:position 1956, :offset 0, :region nil},
    :ref "G",
    :type ">",
    :alt "T"}}}
 {:vcf {:chr "chr4", :pos 1806167, :ref "G", :alt "A"},
  :cdna
  {:transcript "NM_001354810",
   :kind :cdna,
   :mutation
   {:coord {:position 1956, :offset 0, :region nil},
    :ref "G",
    :type ">",
    :alt "A"}}}
 {:vcf {:chr "chr4", :pos 1806167, :ref "G", :alt "C"},
  :cdna
  {:transcript "NM_001354810",
   :kind :cdna,
   :mutation
   {:coord {:position 1956, :offset 0, :region nil},
    :ref "G",
    :type ">",
    :alt "C"}}}
 {:vcf {:chr "chr4", :pos 1806167, :ref "G", :alt "T"},
  :cdna
  {:transcript "NM_001354810",
   :kind :cdna,
   :mutation
   {:coord {:position 1956, :offset 0, :region nil},
    :ref "G",
    :type ">",
    :alt "T"}}}
 {:vcf {:chr "chr4", :pos 1806163, :ref "A", :alt "C"},
  :cdna
  {:transcript "NM_001163213",
   :kind :cdna,
   :mutation
   {:coord {:position 1955, :offset 0, :region nil},
    :ref "A",
    :type ">",
    :alt "C"}}}
 {:vcf {:chr "chr4", :pos 1806170, :ref "C", :alt "A"},
  :cdna
  {:transcript "NM_000142",
   :kind :cdna,
   :mutation
   {:coord {:position 1956, :offset 0, :region nil},
    :ref "C",
    :type ">",
    :alt "A"}}}
 {:vcf {:chr "chr4", :pos 1806170, :ref "C", :alt "G"},
  :cdna
  {:transcript "NM_000142",
   :kind :cdna,
   :mutation
   {:coord {:position 1956, :offset 0, :region nil},
    :ref "C",
    :type ">",
    :alt "G"}}}
 {:vcf {:chr "chr4", :pos 1806170, :ref "C", :alt "T"},
  :cdna
  {:transcript "NM_000142",
   :kind :cdna,
   :mutation
   {:coord {:position 1956, :offset 0, :region nil},
    :ref "C",
    :type ">",
    :alt "T"}}})
```

</details>

#### Cause
`varity.hgvs-to-vcf/hgvs->vcf-variants` and `varity.hgvs-to-vcf/protein-hgvs->vcf-variants-with-cdna-hgvs` don't check if reference amino acids match with the query HGVS.

#### Changes
Check the reference amino acids.

Now both `varity.hgvs-to-vcf/hgvs->vcf-variants` and `varity.hgvs-to-vcf/protein-hgvs->vcf-variants-with-cdna-hgvs` return a single variant.

<details>

```clojure
user> (h2v/hgvs->vcf-variants (hgvs/parse "p.K652T") "FGFR3" reader-hg38 rg-idx-hg38)
({:chr "chr4", :pos 1806163, :ref "A", :alt "C"})

user> (h2v/protein-hgvs->vcf-variants-with-cdna-hgvs (hgvs/parse "p.K652T") "FGFR3" reader-hg38 rg-idx-hg38)
({:vcf {:chr "chr4", :pos 1806163, :ref "A", :alt "C"},
  :cdna
  {:transcript "NM_001163213",
   :kind :cdna,
   :mutation
   {:coord {:position 1955, :offset 0, :region nil},
    :ref "A",
    :type ">",
    :alt "C"}}})
```

</details>

#### Affects
`hgvs-to-vcf`

#### Tests

- `lein check` 🆗
- `lein test :all` 🆗
- `lein eastwood` 🆗