### PR TITLE
Include MNVs in protein HGVS -> VCF conversion results

### DIFF
--- a/src/varity/hgvs_to_vcf/protein.clj
+++ b/src/varity/hgvs_to_vcf/protein.clj
@@ -1,5 +1,7 @@
 (ns varity.hgvs-to-vcf.protein
-  (:require [clj-hgvs.core :as hgvs]
+  (:require [clojure.string :as string]
+            [clojure.tools.logging :as logging]
+            [clj-hgvs.core :as hgvs]
             [clj-hgvs.mutation :as mut]
             [cljam.io.sequence :as cseq]
             [cljam.util.sequence :as util-seq]
@@ -14,11 +16,28 @@
          (keep #(rg/cds->genomic-pos % rg))
          (sort))))
 
-(defn- one-character-substituted?
-  [ref-seq alt-seq pos]
-  (and (not= ref-seq alt-seq)
-       (= (assoc (vec ref-seq) pos nil)
-          (assoc (vec alt-seq) pos nil))))
+(defn- trim-left-right [positions ref alt]
+  (->> (map vector positions ref alt)
+       (drop-while #(apply = (rest %)))
+       reverse
+       (drop-while #(apply = (rest %)))
+       reverse
+       (apply map vector)))
+
+(defn- contiguous? [xs]
+  (when-first [f xs]
+    (let [l (last xs)]
+      (or (= xs (range f (inc l) 1))
+          (= xs (range f (dec l) -1))))))
+
+(defn- codon->variant [positions ref alt]
+  (when-not (= ref alt) ;; not a variant
+    (let [[ps r a] (seq (trim-left-right positions ref alt))]
+      (if (contiguous? ps)
+        [ps (string/join r) (string/join a)]
+        (-> "Ignoring a candidate variant crossing an intron: %s %s %s"
+            (format ps ref alt)
+            logging/warn)))))
 
 (defn- vcf-variants
   [seq-rdr {:keys [chr strand] :as rg} mut*]
@@ -41,19 +60,12 @@
               (->> codon-cands
                    (keep
                     (fn [codon*]
-                      (->> pos-cands*
-                           (map-indexed
-                            (fn [idx pos]
-                              (if (one-character-substituted?
-                                   ref-codon codon* idx)
-                                {:chr chr
-                                 :pos pos
-                                 :ref (cond-> (str (nth ref-codon idx))
-                                        reverse? util-seq/revcomp)
-                                 :alt (cond-> (str (nth codon* idx))
-                                        reverse? util-seq/revcomp)})))
-                           (remove nil?))))
-                   (flatten)))))))
+                      (when-let [[ps ref alt] (codon->variant
+                                               pos-cands* ref-codon codon*)]
+                        {:chr chr,
+                         :pos ((if reverse? last first) ps),
+                         :ref (cond-> ref reverse? util-seq/revcomp),
+                         :alt (cond-> alt reverse? util-seq/revcomp)})))))))))
     (throw (ex-info "Unsupported mutation" {:type ::unsupported-mutation}))))
 
 (defn ->vcf-variants
@@ -77,33 +89,22 @@
           (when (= mut-ref-aa ref-aa)
             (let [palt (mut/->short-amino-acid (:alt mut*))
                   codon-cands (codon/amino-acid->codons palt)
-                  pos-cands (cond-> pos-cands reverse? reverse)]
+                  pos-cands* (cond-> pos-cands reverse? reverse)]
               (->> codon-cands
                    (keep
                     (fn [codon*]
-                      (->> pos-cands
-                           (map-indexed
-                            (fn [idx pos]
-                              (if (one-character-substituted?
-                                   ref-codon codon* idx)
-                                (let [ref (str (nth ref-codon idx))
-                                      alt (str (nth codon* idx))]
-                                  {:vcf {:chr chr
-                                         :pos pos
-                                         :ref (cond-> ref
-                                                reverse? util-seq/revcomp)
-                                         :alt (cond-> alt
-                                                reverse? util-seq/revcomp)}
-                                   :cdna (hgvs/hgvs
-                                          (:name rg)
-                                          :cdna
-                                          (mut/dna-substitution
-                                           (rg/cds-coord pos rg)
-                                           ref
-                                           (if (= ref alt) "=" ">")
-                                           alt))}))))
-                           (remove nil?))))
-                   (flatten)))))))
+                      (when-let [[ps ref alt] (codon->variant
+                                               pos-cands* ref-codon codon*)]
+                        (let [cds-pos (rg/cds-coord (first ps) rg)
+                              cds-end (rg/cds-coord (last ps) rg)
+                              mut (if-not (= cds-pos cds-end)
+                                    (mut/dna-indel cds-pos cds-end nil alt)
+                                    (mut/dna-substitution cds-pos ref ">" alt))]
+                          {:vcf {:chr chr,
+                                 :pos ((if reverse? last first) ps),
+                                 :ref (cond-> ref reverse? util-seq/revcomp),
+                                 :alt (cond-> alt reverse? util-seq/revcomp)},
+                           :cdna (hgvs/hgvs (:name rg) :cdna mut)}))))))))))
     (throw (IllegalArgumentException. "Unsupported mutation"))))
 
 (defn ->vcf-variants-with-cdna-hgvs

--- a/src/varity/hgvs_to_vcf/protein.clj
+++ b/src/varity/hgvs_to_vcf/protein.clj
@@ -35,9 +35,9 @@
     (let [[ps r a] (seq (trim-left-right positions ref alt))]
       (if (contiguous? ps)
         [ps (string/join r) (string/join a)]
-        (-> "Ignoring a candidate variant crossing an intron: %s %s %s"
-            (format ps ref alt)
-            log/warn)))))
+        (log/warnf
+         "A candidate variant crossing an intron is unsupported: %s %s %s"
+         ps r a)))))
 
 (defn- vcf-variants
   [seq-rdr {:keys [chr strand] :as rg} mut*]

--- a/src/varity/hgvs_to_vcf/protein.clj
+++ b/src/varity/hgvs_to_vcf/protein.clj
@@ -98,7 +98,7 @@
                         (let [cds-pos (rg/cds-coord (first ps) rg)
                               cds-end (rg/cds-coord (last ps) rg)
                               mut (if-not (= cds-pos cds-end)
-                                    (mut/dna-indel cds-pos cds-end nil alt)
+                                    (mut/dna-indel cds-pos cds-end ref alt)
                                     (mut/dna-substitution cds-pos ref ">" alt))]
                           {:vcf {:chr chr,
                                  :pos ((if reverse? last first) ps),

--- a/src/varity/hgvs_to_vcf/protein.clj
+++ b/src/varity/hgvs_to_vcf/protein.clj
@@ -1,6 +1,6 @@
 (ns varity.hgvs-to-vcf.protein
   (:require [clojure.string :as string]
-            [clojure.tools.logging :as logging]
+            [clojure.tools.logging :as log]
             [clj-hgvs.core :as hgvs]
             [clj-hgvs.mutation :as mut]
             [cljam.io.sequence :as cseq]
@@ -37,7 +37,7 @@
         [ps (string/join r) (string/join a)]
         (-> "Ignoring a candidate variant crossing an intron: %s %s %s"
             (format ps ref alt)
-            logging/warn)))))
+            log/warn)))))
 
 (defn- vcf-variants
   [seq-rdr {:keys [chr strand] :as rg} mut*]

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -116,25 +116,25 @@
         "p.L1196M" "ALK" `({:vcf {:chr "chr2", :pos 29220765, :ref "G", :alt "T"} ; cf. rs1057519784
                             :cdna ~(hgvs/parse "NM_004304:c.3586C>A")})
         "p.Q61L" "NRAS" `({:vcf {:chr "chr1", :pos 114713907, :ref "TT", :alt "CA"}, ; cf. rs1057519695
-                           :cdna ~(hgvs/parse "NM_002524:c.182_183delinsTG")}
+                           :cdna ~(hgvs/parse "NM_002524:c.182_183delAAinsTG")}
                           {:vcf {:chr "chr1", :pos 114713907, :ref "TT", :alt "GA"},
-                           :cdna ~(hgvs/parse "NM_002524:c.182_183delinsTC")}
+                           :cdna ~(hgvs/parse "NM_002524:c.182_183delAAinsTC")}
                           {:vcf {:chr "chr1", :pos 114713907, :ref "TT", :alt "AA"},
-                           :cdna ~(hgvs/parse "NM_002524:c.182_183delinsTT")}
+                           :cdna ~(hgvs/parse "NM_002524:c.182_183delAAinsTT")}
                           {:vcf {:chr "chr1", :pos 114713908, :ref "T", :alt "A"}, ; cf. rs11554290
                            :cdna ~(hgvs/parse "NM_002524:c.182A>T")}
                           {:vcf {:chr "chr1", :pos 114713907, :ref "TTG", :alt "CAA"},
-                           :cdna ~(hgvs/parse "NM_002524:c.181_183delinsTTG")}
+                           :cdna ~(hgvs/parse "NM_002524:c.181_183delCAAinsTTG")}
                           {:vcf {:chr "chr1", :pos 114713908, :ref "TG", :alt "AA"},
-                           :cdna ~(hgvs/parse "NM_002524:c.181_182delinsTT")})
+                           :cdna ~(hgvs/parse "NM_002524:c.181_182delCAinsTT")})
         "p.K652T" "FGFR3" `({:vcf {:chr "chr4", :pos 1806163, :ref "AG", :alt "CA"},
-                             :cdna ~(hgvs/parse "NM_001163213:c.1955_1956delinsCA")}
+                             :cdna ~(hgvs/parse "NM_001163213:c.1955_1956delAGinsCA")}
                             {:vcf {:chr "chr4", :pos 1806163, :ref "AG", :alt "CC"},
-                             :cdna ~(hgvs/parse "NM_001163213:c.1955_1956delinsCC")}
+                             :cdna ~(hgvs/parse "NM_001163213:c.1955_1956delAGinsCC")}
                             {:vcf {:chr "chr4", :pos 1806163, :ref "A", :alt "C"},
                              :cdna ~(hgvs/parse "NM_001163213:c.1955A>C")} ; cf. rs121913105
                             {:vcf {:chr "chr4", :pos 1806163, :ref "AG", :alt "CT"},
-                             :cdna ~(hgvs/parse "NM_001163213:c.1955_1956delinsCT")})))))
+                             :cdna ~(hgvs/parse "NM_001163213:c.1955_1956delAGinsCT")})))))
 
 (defslowtest hgvs->vcf->hgvs-test
   (cavia-testing "protein HGVS with gene to possible vcf variants which gives the same protein HGVS"

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -89,12 +89,24 @@
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [hgvs* gene e]
           (= (hgvs->vcf-variants (hgvs/parse hgvs*) gene test-ref-seq-file rgidx) e)
-        "p.L858R" "EGFR" '({:chr "chr7", :pos 55191822, :ref "T", :alt "G"}) ; cf. rs121434568
-        "p.A222V" "MTHFR" '({:chr "chr1", :pos 11796321, :ref "G", :alt "A"}) ; cf. rs1801133
-        "p.Q61K" "NRAS" '({:chr "chr1", :pos 114713909, :ref "G", :alt "T"}) ; cf. rs121913254
-        "p.Q61K" "KRAS" '({:chr "chr12", :pos 25227343, :ref "G", :alt "T"}) ; cf. rs121913238
-        "p.K652T" "FGFR3" '({:chr "chr4", :pos 1806163, :ref "A", :alt "C"}) ; cf. rs121913105
-        )))
+        "p.L858R" "EGFR" '({:chr "chr7", :pos 55191822, :ref "TG", :alt "GC"}
+                           {:chr "chr7", :pos 55191822, :ref "TG", :alt "GT"}  ; cf. rs1057519848
+                           {:chr "chr7", :pos 55191822, :ref "T", :alt "G"}    ; cf. rs121434568
+                           {:chr "chr7", :pos 55191822, :ref "TG", :alt "GA"}
+                           {:chr "chr7", :pos 55191821, :ref "CTG", :alt "AGA"}
+                           {:chr "chr7", :pos 55191821, :ref "CT", :alt "AG"}) ; cf. rs1057519847
+        "p.A222V" "MTHFR" '({:chr "chr1", :pos 11796320, :ref "GG", :alt "CA"}
+                            {:chr "chr1", :pos 11796320, :ref "GG", :alt "AA"}
+                            {:chr "chr1", :pos 11796320, :ref "GG", :alt "TA"}
+                            {:chr "chr1", :pos 11796321, :ref "G", :alt "A"})  ; cf. rs1801133
+        "p.Q61K" "NRAS" '({:chr "chr1", :pos 114713907, :ref "TTG", :alt "CTT"}
+                          {:chr "chr1", :pos 114713909, :ref "G", :alt "T"})   ; cf. rs121913254
+        "p.Q61K" "KRAS" '({:chr "chr12", :pos 25227341, :ref "TTG", :alt "CTT"}
+                          {:chr "chr12", :pos 25227343, :ref "G", :alt "T"})   ; cf. rs121913238
+        "p.K652T" "FGFR3" '({:chr "chr4", :pos 1806163, :ref "AG", :alt "CA"}
+                            {:chr "chr4", :pos 1806163, :ref "AG", :alt "CC"}
+                            {:chr "chr4", :pos 1806163, :ref "A", :alt "C"}    ; cf. rs121913105
+                            {:chr "chr4", :pos 1806163, :ref "AG", :alt "CT"}))))
   (cavia-testing "protein HGVS with gene to possible vcf variants with cDNA HGVS"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [hgvs* gene e]
@@ -103,8 +115,26 @@
                             :cdna ~(hgvs/parse "NM_005228:c.2369C>T")})
         "p.L1196M" "ALK" `({:vcf {:chr "chr2", :pos 29220765, :ref "G", :alt "T"} ; cf. rs1057519784
                             :cdna ~(hgvs/parse "NM_004304:c.3586C>A")})
-        "p.K652T" "FGFR3" `({:vcf {:chr "chr4", :pos 1806163, :ref "A", :alt "C"},; cf. rs121913105
-                             :cdna ~(hgvs/parse "NM_001163213:c.1955A>C")})))))
+        "p.Q61L" "NRAS" `({:vcf {:chr "chr1", :pos 114713907, :ref "TT", :alt "CA"}, ; cf. rs1057519695
+                           :cdna ~(hgvs/parse "NM_002524:c.182_183delinsTG")}
+                          {:vcf {:chr "chr1", :pos 114713907, :ref "TT", :alt "GA"},
+                           :cdna ~(hgvs/parse "NM_002524:c.182_183delinsTC")}
+                          {:vcf {:chr "chr1", :pos 114713907, :ref "TT", :alt "AA"},
+                           :cdna ~(hgvs/parse "NM_002524:c.182_183delinsTT")}
+                          {:vcf {:chr "chr1", :pos 114713908, :ref "T", :alt "A"}, ; cf. rs11554290
+                           :cdna ~(hgvs/parse "NM_002524:c.182A>T")}
+                          {:vcf {:chr "chr1", :pos 114713907, :ref "TTG", :alt "CAA"},
+                           :cdna ~(hgvs/parse "NM_002524:c.181_183delinsTTG")}
+                          {:vcf {:chr "chr1", :pos 114713908, :ref "TG", :alt "AA"},
+                           :cdna ~(hgvs/parse "NM_002524:c.181_182delinsTT")})
+        "p.K652T" "FGFR3" `({:vcf {:chr "chr4", :pos 1806163, :ref "AG", :alt "CA"},
+                             :cdna ~(hgvs/parse "NM_001163213:c.1955_1956delinsCA")}
+                            {:vcf {:chr "chr4", :pos 1806163, :ref "AG", :alt "CC"},
+                             :cdna ~(hgvs/parse "NM_001163213:c.1955_1956delinsCC")}
+                            {:vcf {:chr "chr4", :pos 1806163, :ref "A", :alt "C"},
+                             :cdna ~(hgvs/parse "NM_001163213:c.1955A>C")} ; cf. rs121913105
+                            {:vcf {:chr "chr4", :pos 1806163, :ref "AG", :alt "CT"},
+                             :cdna ~(hgvs/parse "NM_001163213:c.1955_1956delinsCT")})))))
 
 (defslowtest hgvs->vcf->hgvs-test
   (cavia-testing "protein HGVS with gene to possible vcf variants which gives the same protein HGVS"


### PR DESCRIPTION
#### Summary
When converting HGVS of protein substitutions to VCF variants, only SNVs are picked up by `one-character-substituted?`.
I felt like it would be nice if varity had a feature to convert HGVS into MNVs too.
This PR modifies `hgvs->vcf-variants` and `protein-hgvs->vcf-variants-with-cdna-hgvs` so that they include MNVs in results.
Please let me know if I should better define other functions instead of changing existing ones.

#### Tests

- `lein check` 🆗
- `lein test :all` 🆗
- `lein eastwood` 🆗