### PR TITLE
Throw ex-info on hgvs->vcf for a variant containing ambiguous coordinates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,25 @@
 language: clojure
-lein: 2.8.1
+lein: 2.9.1
 cache:
   directories:
     - $HOME/.m2
 jdk:
-  - oraclejdk8
-  - oraclejdk9
-  # - oraclejdk10 # temporarily disabled (see https://github.com/travis-ci/travis-ci/issues/10249)
   - openjdk8
   - openjdk9
   - openjdk10
   - openjdk11
+  - openjdk12
 before_install: if [ -f "${JAVA_HOME}/lib/security/cacerts" -a -w  "${JAVA_HOME}/lib/security/cacerts" ]; then rm "${JAVA_HOME}/lib/security/cacerts" && ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"; fi
 script: lein with-profile +dev:+1.8:+1.10 test
 jobs:
   include:
     - stage: coverage
-      jdk: oraclejdk8
+      jdk: openjdk8
       script:
         - lein cloverage --codecov
         - bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
     - stage: deploy
-      jdk: oraclejdk8
+      jdk: openjdk8
       script: skip
       deploy:
         provider: script

--- a/src/varity/hgvs_to_vcf/cdna.clj
+++ b/src/varity/hgvs_to_vcf/cdna.clj
@@ -1,8 +1,24 @@
 (ns varity.hgvs-to-vcf.cdna
-  (:require clj-hgvs.mutation
+  (:require clj-hgvs.coordinate
+            clj-hgvs.mutation
             [cljam.io.sequence :as cseq]
             [cljam.util.sequence :as util-seq]
             [varity.ref-gene :as rg]))
+
+(defn- cds-coord->genomic-pos
+  [coord rg]
+  (cond
+    (instance? clj_hgvs.coordinate.CDNACoordinate coord)
+    (rg/cds-coord->genomic-pos coord rg)
+
+    (or (instance? clj_hgvs.coordinate.UnknownCoordinate coord)
+        (instance? clj_hgvs.coordinate.UncertainCoordinate coord))
+    (throw (ex-info "Ambiguous coordinate" {:type ::ambiguous-coordinate
+                                            :coordinate coord}))
+
+    :else
+    (throw (IllegalArgumentException.
+            "coord must be clj-hgvs.coordinate/CDNACoordinate record"))))
 
 ;; AGT => ["AGT"]
 ;; AGTAGT => ["AGT" "AGTAGT"]
@@ -19,7 +35,7 @@
 
 (defmethod vcf-variant clj_hgvs.mutation.DNASubstitution
   [mut* _ {:keys [chr strand] :as rg}]
-  (if-let [pos (rg/cds-coord->genomic-pos (:coord mut*) rg)]
+  (if-let [pos (cds-coord->genomic-pos (:coord mut*) rg)]
     (let [alt (if (= (:type mut*) "=")
                 (:ref mut*)
                 (:alt mut*))]
@@ -33,14 +49,14 @@
 (defmethod vcf-variant clj_hgvs.mutation.DNADeletion
   [mut* seq-rdr {:keys [chr strand] :as rg}]
   (let [coord-end (or (:coord-end mut*) (:coord-start mut*))
-        start (rg/cds-coord->genomic-pos (case strand
-                                           :forward (:coord-start mut*)
-                                           :reverse coord-end)
-                                         rg)
-        end (rg/cds-coord->genomic-pos (case strand
-                                         :forward coord-end
-                                         :reverse (:coord-start mut*))
-                                       rg)]
+        start (cds-coord->genomic-pos (case strand
+                                        :forward (:coord-start mut*)
+                                        :reverse coord-end)
+                                      rg)
+        end (cds-coord->genomic-pos (case strand
+                                      :forward coord-end
+                                      :reverse (:coord-start mut*))
+                                    rg)]
     (if (and start end)
       (let [ref (cseq/read-sequence seq-rdr {:chr chr, :start (dec start), :end end})]
         {:chr chr
@@ -51,14 +67,14 @@
 (defmethod vcf-variant clj_hgvs.mutation.DNADuplication
   [mut* seq-rdr {:keys [chr strand] :as rg}]
   (let [coord-end (or (:coord-end mut*) (:coord-start mut*))
-        start (rg/cds-coord->genomic-pos (case strand
-                                           :forward (:coord-start mut*)
-                                           :reverse coord-end)
-                                         rg)
-        end (rg/cds-coord->genomic-pos (case strand
-                                         :forward coord-end
-                                         :reverse (:coord-start mut*))
-                                       rg)]
+        start (cds-coord->genomic-pos (case strand
+                                        :forward (:coord-start mut*)
+                                        :reverse coord-end)
+                                      rg)
+        end (cds-coord->genomic-pos (case strand
+                                      :forward coord-end
+                                      :reverse (:coord-start mut*))
+                                    rg)]
     (if (and start end)
       (let [dup (cseq/read-sequence seq-rdr {:chr chr, :start start, :end end})
             base (case strand
@@ -73,10 +89,10 @@
 
 (defmethod vcf-variant clj_hgvs.mutation.DNAInsertion
   [mut* seq-rdr {:keys [chr strand] :as rg}]
-  (if-let [start (rg/cds-coord->genomic-pos (case strand
-                                              :forward (:coord-start mut*)
-                                              :reverse (:coord-end mut*))
-                                            rg)]
+  (if-let [start (cds-coord->genomic-pos (case strand
+                                           :forward (:coord-start mut*)
+                                           :reverse (:coord-end mut*))
+                                         rg)]
     (let [ref (cseq/read-sequence seq-rdr {:chr chr, :start start, :end start})]
       {:chr chr
        :pos start
@@ -86,14 +102,14 @@
 
 (defmethod vcf-variant clj_hgvs.mutation.DNAInversion
   [mut* seq-rdr {:keys [chr strand] :as rg}]
-  (let [start (rg/cds-coord->genomic-pos (case strand
-                                           :forward (:coord-start mut*)
-                                           :reverse (:coord-end mut*))
-                                         rg)
-        end (rg/cds-coord->genomic-pos (case strand
-                                         :forward (:coord-end mut*)
-                                         :reverse (:coord-start mut*))
-                                       rg)]
+  (let [start (cds-coord->genomic-pos (case strand
+                                        :forward (:coord-start mut*)
+                                        :reverse (:coord-end mut*))
+                                      rg)
+        end (cds-coord->genomic-pos (case strand
+                                      :forward (:coord-end mut*)
+                                      :reverse (:coord-start mut*))
+                                    rg)]
     (if (and start end)
       (let [ref (cseq/read-sequence seq-rdr {:chr chr, :start (dec start), :end end})]
         {:chr chr
@@ -104,14 +120,14 @@
 (defmethod vcf-variant clj_hgvs.mutation.DNAIndel
   [mut* seq-rdr {:keys [chr strand] :as rg}]
   (let [coord-end (or (:coord-end mut*) (:coord-start mut*))
-        start (rg/cds-coord->genomic-pos (case strand
-                                           :forward (:coord-start mut*)
-                                           :reverse coord-end)
-                                         rg)
-        end (rg/cds-coord->genomic-pos (case strand
-                                         :forward coord-end
-                                         :reverse (:coord-start mut*))
-                                       rg)]
+        start (cds-coord->genomic-pos (case strand
+                                        :forward (:coord-start mut*)
+                                        :reverse coord-end)
+                                      rg)
+        end (cds-coord->genomic-pos (case strand
+                                      :forward coord-end
+                                      :reverse (:coord-start mut*))
+                                    rg)]
     (if (and start end)
       (let [ref (cseq/read-sequence seq-rdr {:chr chr, :start (dec start), :end end})]
         (if (or (nil? (:ref mut*))
@@ -125,9 +141,9 @@
 
 (defmethod vcf-variant clj_hgvs.mutation.DNARepeatedSeqs
   [mut* seq-rdr {:keys [chr strand] :as rg}]
-  (let [start* (rg/cds-coord->genomic-pos (:coord-start mut*) rg)
+  (let [start* (cds-coord->genomic-pos (:coord-start mut*) rg)
         end* (cond
-               (:coord-end mut*) (rg/cds-coord->genomic-pos (:coord-end mut*) rg)
+               (:coord-end mut*) (cds-coord->genomic-pos (:coord-end mut*) rg)
                (:ref mut*) (dec (+ start* (count (:ref mut*))))
                :else start*)]
     (if (and start* end*)

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -106,7 +106,9 @@
         "p.K652T" "FGFR3" '({:chr "chr4", :pos 1806163, :ref "AG", :alt "CA"}
                             {:chr "chr4", :pos 1806163, :ref "AG", :alt "CC"}
                             {:chr "chr4", :pos 1806163, :ref "A", :alt "C"}    ; cf. rs121913105
-                            {:chr "chr4", :pos 1806163, :ref "AG", :alt "CT"}))))
+                            {:chr "chr4", :pos 1806163, :ref "AG", :alt "CT"})))))
+
+(defslowtest protein-hgvs->vcf-variants-with-cdna-hgvs-test
   (cavia-testing "protein HGVS with gene to possible vcf variants with cDNA HGVS"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [hgvs* gene e]

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -4,6 +4,7 @@
             [cljam.io.sequence :as cseq]
             [varity.ref-gene :as rg]
             [varity.hgvs-to-vcf :refer :all]
+            [varity.hgvs-to-vcf.cdna :as h2v-cdna]
             [varity.t-common :refer :all]
             [varity.vcf-to-hgvs :as v2h]))
 
@@ -106,7 +107,21 @@
         "p.K652T" "FGFR3" '({:chr "chr4", :pos 1806163, :ref "AG", :alt "CA"}
                             {:chr "chr4", :pos 1806163, :ref "AG", :alt "CC"}
                             {:chr "chr4", :pos 1806163, :ref "A", :alt "C"}    ; cf. rs121913105
-                            {:chr "chr4", :pos 1806163, :ref "AG", :alt "CT"})))))
+                            {:chr "chr4", :pos 1806163, :ref "AG", :alt "CT"}))))
+  (cavia-testing "conversion failure"
+    (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
+      (are [hgvs* error-type] (thrown-with-error-type?
+                               error-type
+                               (hgvs->vcf-variants (hgvs/parse hgvs*)
+                                                   test-ref-seq-file rgidx))
+        "NM_007294:c.1-?_80+?del"   ::h2v-cdna/ambiguous-coordinate
+        "NM_000546:c.-202_-29+?dup" ::h2v-cdna/ambiguous-coordinate)
+      (are [hgvs* gene error-type] (thrown-with-error-type?
+                                    error-type
+                                    (hgvs->vcf-variants (hgvs/parse hgvs*) gene
+                                                        test-ref-seq-file rgidx))
+        "c.1-?_80+?del"   "BRCA1" ::h2v-cdna/ambiguous-coordinate
+        "c.-202_-29+?dup" "TP53"  ::h2v-cdna/ambiguous-coordinate))))
 
 (defslowtest protein-hgvs->vcf-variants-with-cdna-hgvs-test
   (cavia-testing "protein HGVS with gene to possible vcf variants with cDNA HGVS"


### PR DESCRIPTION
Current hgvs->vcf throws NPE when a variant containing ambiguous coordinates is supplied.

```clj
(require '[varity.hgvs-to-vcf :as h2v]
         '[clj-hgvs.core :as hgvs])

(h2v/hgvs->vcf-variants (hgvs/parse "NM_007294:c.1-?_80+?del")
                        "path/to/fasta.fa"
                        "path/to/refGene.txt")
;; NullPointerException   clojure.lang.Numbers.ops (Numbers.java:1018)
```

`NM_007294:c.1-?_80+?del` is totally correct as a coding DNA HGVS, but it
cannot be converted to a VCF variant because genomic positions are underspecified.
I modified cds-coord->genomic-pos to throw ex-info with `:ambiguous-coordinate`
error type when such a coordinate is passed.

```clj
(try
  (h2v/hgvs->vcf-variants (hgvs/parse "NM_007294:c.1-?_80+?del")
                          "path/to/fasta.fa"
                          "path/to/refGene.txt")
  (catch Exception e
    (ex-data e)))
;;=> {:type :varity.hgvs-to-vcf.cdna/ambiguous-coordinate,
;;    :coordinate {:start {:position 80, :offset 1, :region nil}, :end {}}}
```

This patch is useful for error handling on hgvs->vcf.

And besides, I removed oraclejdk from CI because they cause build failure ([Build #229](https://travis-ci.org/chrovis/varity/builds/545190350)).
That may be resolved if [using Trusty instead of Xenial](https://travis-ci.community/t/the-travis-ci-build-could-not-be-completed-due-to-an-error/1345/7), but I think only tests with OpenJDK are enough for this library.

I confirmed `lein test :all` passed.
