### PR TITLE
Fix conversion from reverse-strand repeated sequences to VCF variant

### DIFF
--- a/src/varity/hgvs_to_vcf/coding_dna.clj
+++ b/src/varity/hgvs_to_vcf/coding_dna.clj
@@ -144,7 +144,9 @@
   (let [start* (cds-coord->genomic-pos (:coord-start mut*) rg)
         end* (cond
                (:coord-end mut*) (cds-coord->genomic-pos (:coord-end mut*) rg)
-               (:ref mut*) (dec (+ start* (count (:ref mut*))))
+               (:ref mut*) (when start*
+                             (+ start* (cond-> (dec (count (:ref mut*)))
+                                         (= strand :reverse) -)))
                :else start*)]
     (if (and start* end*)
       (let [[start end] (cond-> [start* end*] (= strand :reverse) reverse)

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -41,7 +41,9 @@
 
         ;; repeated sequences
         "NM_005228:c.2571_2573[3]" '({:chr "chr7", :pos 55191822, :ref "T", :alt "TGCTGCT"})
+        "NM_005228:c.2571GCT[3]" '({:chr "chr7", :pos 55191822, :ref "T", :alt "TGCTGCT"})
         "NM_144639:c.1510-122_1510-121[3]" '({:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"}) ; cf. rs2307882 (-)
+        "NM_144639:c.1510-122AG[3]" '({:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"})
         "NM_004369:c.6063+6[9]" '({:chr "chr2", :pos 237363246, :ref "A", :alt "AA"}) ; cf. rs11385011 (-)
         )))
   (cavia-testing "coding DNA HGVS with gene to vcf variants"
@@ -81,7 +83,9 @@
 
         ;; repeated sequences
         "c.2571_2573[3]" "EGFR" '({:chr "chr7", :pos 55191822, :ref "T", :alt "TGCTGCT"})
+        "c.2571GCT[3]" "EGFR" '({:chr "chr7", :pos 55191822, :ref "T", :alt "TGCTGCT"})
         "c.1510-122_1510-121[3]" "UROC1" '({:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"}) ; cf. rs2307882 (-)
+        "c.1510-122AG[3]" "UROC1" '({:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"})
         "c.6063+6[9]" "COL6A3" '({:chr "chr2", :pos 237363246, :ref "A", :alt "AA"}
                                  {:chr "chr2", :pos 237341025, :ref "T", :alt "TGGGGG"}
                                  {:chr "chr2", :pos 237353343, :ref "G", :alt "GTTTTTT"}) ; cf. rs11385011 (-)


### PR DESCRIPTION
Repeated sequences can be expressed with bases (e.g. `NM_005228:c.2571GCT[3]`) as well as a range (e.g. `NM_005228:c.2571_2573[3]`).

I found a bug of conversion from reverse-strand (-) repeated sequences with bases to VCF variant.

```clj
(require '[varity.hgvs-to-vcf :as h2v])

;; correct (range expression)
(h2v/hgvs->vcf-variants #clj-hgvs/hgvs "NM_144639:c.1510-122_1510-121[3]"
                        "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> ({:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"})

;; incorrect (base expression)
(h2v/hgvs->vcf-variants #clj-hgvs/hgvs "NM_144639:c.1510-122AG[3]"
                        "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> ()
```

This PR fixes it.

```clj
(h2v/hgvs->vcf-variants #clj-hgvs/hgvs "NM_144639:c.1510-122AG[3]"
                        "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> ({:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"})
```

I confirmed `lein test :all` passed.