### PR TITLE
Support repeated sequences caused by deletion on VCF->HGVS

### DIFF
--- a/src/varity/vcf_to_hgvs/coding_dna.clj
+++ b/src/varity/vcf_to_hgvs/coding_dna.clj
@@ -194,7 +194,7 @@
                                                    ref-only alt-only)
         nunit (count unit)
         start (case strand
-                :forward (+ pos offset (- (* nunit ref-repeat)))
+                :forward (+ pos offset (- (* nunit (min ref-repeat alt-repeat))))
                 :reverse (+ pos offset (* nunit ref-repeat) -1))
         end (case strand
               :forward (dec (+ start nunit))

--- a/src/varity/vcf_to_hgvs/coding_dna.clj
+++ b/src/varity/vcf_to_hgvs/coding_dna.clj
@@ -11,16 +11,21 @@
             [varity.vcf-to-hgvs.common :refer [diff-bases] :as common]))
 
 (defn- repeat-info-forward
-  [seq-rdr rg pos ins]
+  [seq-rdr rg pos alt type]
   (->> (common/read-sequence-stepwise-backward
         seq-rdr
         {:chr (:chr rg)
          :start (- (:tx-start rg) rg/max-tx-margin)
-         :end (dec pos)}
+         :end (dec (cond-> pos
+                     (= type :del) (+ (count alt))))}
         100)
        (map (fn [seq*]
-              (let [nseq* (count seq*)]
-                (if-let [[unit ref-repeat :as ri] (common/repeat-info seq* (inc nseq*) ins)]
+              (let [nseq* (count seq*)
+                    pos* (case type
+                           :ins (inc nseq*)
+                           :del (inc (- nseq* (count alt))))]
+                (if-let [[unit ref-repeat :as ri] (common/repeat-info
+                                                   seq* pos* alt type)]
                   (let [nunit (count unit)]
                     (if (> (* nunit ref-repeat) (- nseq* nunit))
                       false
@@ -29,7 +34,7 @@
        (first)))
 
 (defn- repeat-info-backward
-  [seq-rdr rg pos ins]
+  [seq-rdr rg pos alt type]
   (->> (common/read-sequence-stepwise
         seq-rdr
         {:chr (:chr rg)
@@ -37,10 +42,15 @@
          :end (+ (:tx-end rg) rg/max-tx-margin)}
         100)
        (map (fn [seq*]
-              (let [nseq* (count seq*)]
-                (if-let [[unit ref-repeat :as ri] (common/repeat-info (util-seq/revcomp seq*)
-                                                                      (inc nseq*)
-                                                                      (util-seq/revcomp ins))]
+              (let [nseq* (count seq*)
+                    pos* (case type
+                           :ins (inc nseq*)
+                           :del (inc (- nseq* (count alt))))]
+                (if-let [[unit ref-repeat :as ri] (common/repeat-info
+                                                   (util-seq/revcomp seq*)
+                                                   pos*
+                                                   (util-seq/revcomp alt)
+                                                   type)]
                   (let [nunit (count unit)]
                     (if (> (* nunit ref-repeat) (- nseq* nunit))
                       false
@@ -49,26 +59,39 @@
        (first)))
 
 (defn- repeat-info*
-  [seq-rdr rg pos ins]
-  (case (:strand rg)
-    :forward (repeat-info-forward seq-rdr rg pos ins)
-    :reverse (repeat-info-backward seq-rdr rg pos ins)))
+  [seq-rdr rg pos ref-only alt-only]
+  (when-let [[alt type] (cond
+                          (and (empty? ref-only) (seq alt-only)) [alt-only :ins]
+                          (and (seq ref-only) (empty? alt-only)) [ref-only :del])]
+    (case (:strand rg)
+      :forward (repeat-info-forward seq-rdr rg pos alt type)
+      :reverse (repeat-info-backward seq-rdr rg pos alt type))))
 
 (defn- mutation-type
-  [seq-rdr rg pos ref alt]
+  [seq-rdr rg pos ref alt {:keys [prefer-deletion?]}]
   (if (re-matches #"[acgntACGNT]*" alt)
     (let [[ref-only alt-only offset _] (diff-bases ref alt)
           nrefo (count ref-only)
           nalto (count alt-only)
-          [unit ref-repeat ins-repeat] (repeat-info* seq-rdr rg (+ pos offset) alt-only)]
+          [unit ref-repeat alt-repeat] (repeat-info* seq-rdr rg (+ pos offset)
+                                                     ref-only alt-only)]
       (cond
         (or (= nrefo nalto 0) (= nrefo nalto 1)) :substitution
+        (and prefer-deletion? (pos? nrefo) (zero? nalto)) :deletion
         (= ref-only (util-seq/revcomp alt-only)) :inversion
+        (and (some? unit) (= ref-repeat 1) (= alt-repeat 2)) :duplication
+        (and (some? unit) (pos? alt-repeat)
+             ;; In the protein coding region, repeat descriptions are used only
+             ;; for repeat units with a length which is a multiple of 3, i.e.
+             ;; which can not affect the reading frame.
+             ;; See https://varnomen.hgvs.org/recommendations/DNA/variant/repeated/#note
+             (if (and (rg/in-exon? (+ pos offset) rg)
+                      (rg/in-exon? (+ pos offset (count ref-only) -1) rg))
+               (zero? (mod (count unit) 3))
+               true)) :repeated-seqs
         (and (pos? nrefo) (zero? nalto)) :deletion
         (and (pos? nrefo) (pos? nalto)) :indel
-        (some? unit) (cond
-                       (and (= ref-repeat 1) (= ins-repeat 1)) :duplication
-                       (or (> ref-repeat 1) (> ins-repeat 1)) :repeated-seqs)
+        (some? unit) :duplication
         (and (zero? nrefo) (pos? nalto)) :insertion
         :else (throw (ex-info "Unsupported variant" {:type ::unsupported-variant}))))
     (throw (ex-info "Unsupported variant" {:type ::unsupported-variant}))))
@@ -166,8 +189,9 @@
 (defn- dna-repeated-seqs
   [seq-rdr rg pos ref alt]
   (let [{:keys [strand]} rg
-        [_ ins offset _] (diff-bases ref alt)
-        [unit ref-repeat ins-repeat] (repeat-info* seq-rdr rg (+ pos offset) ins)
+        [ref-only alt-only offset _] (diff-bases ref alt)
+        [unit ref-repeat alt-repeat] (repeat-info* seq-rdr rg (+ pos offset)
+                                                   ref-only alt-only)
         nunit (count unit)
         start (case strand
                 :forward (+ pos offset (- (* nunit ref-repeat)))
@@ -178,11 +202,11 @@
     (mut/dna-repeated-seqs (rg/cds-coord start rg)
                            (rg/cds-coord end rg)
                            unit
-                           (+ ref-repeat ins-repeat))))
+                           alt-repeat)))
 
 (defn- mutation
-  [seq-rdr rg pos ref alt]
-  (case (mutation-type seq-rdr rg pos ref alt)
+  [seq-rdr rg pos ref alt options]
+  (case (mutation-type seq-rdr rg pos ref alt options)
     :substitution (dna-substitution rg pos ref alt)
     :deletion (dna-deletion rg pos ref alt)
     :duplication (dna-duplication rg pos ref alt)
@@ -192,10 +216,12 @@
     :repeated-seqs (dna-repeated-seqs seq-rdr rg pos ref alt)))
 
 (defn ->hgvs
-  [{:keys [pos ref alt]} seq-rdr rg]
-  (hgvs/hgvs (:name rg)
-             :coding-dna
-             (mutation seq-rdr rg pos ref alt)))
+  ([variant seq-rdr rg]
+   (->hgvs variant seq-rdr rg {}))
+  ([{:keys [pos ref alt]} seq-rdr rg options]
+   (hgvs/hgvs (:name rg)
+              :coding-dna
+              (mutation seq-rdr rg pos ref alt options))))
 
 (defn- sequence-pstring
   [ref-seq alt-seq start end {:keys [pos ref alt]} rg]

--- a/test/varity/vcf_to_hgvs/common_test.clj
+++ b/test/varity/vcf_to_hgvs/common_test.clj
@@ -58,10 +58,16 @@
       "" 7 "A")))
 
 (deftest repeat-info-test
-  (are [s p i e] (= (common/repeat-info s p i) e)
-    "XXXCAGTCXXX" 8 "AGT" ["AGT" 1 1]
-    "XXXCAGTCXXX" 8 "AGTAGT" ["AGT" 1 2]
-    "XXXCAGTAGTCXXX" 11 "AGTAGT" ["AGT" 2 2]))
+  (are [s p a t e] (= (common/repeat-info s p a t) e)
+    "XXXCAGTCXXX"       8  "AGT"    :ins ["AGT" 1 2]
+    "XXXCAGTCXXX"       8  "AGTAGT" :ins ["AGT" 1 3]
+    "XXXCAGTAGTCXXX"    11 "AGTAGT" :ins ["AGT" 2 4]
+    "XXXCAGTAGTAGTCXXX" 11 "AGT"    :del ["AGT" 3 2]
+    "XXXCAGTAGTAGTCXXX" 8  "AGTAGT" :del ["AGT" 3 1])
+  (are [s p a t] (nil? (common/repeat-info s p a t))
+    "XXXCAGTCXXX"       8  "ATG" :ins
+    "XXXCAGTAGTAGTCXXX" 11 "ATG" :del
+    "XXXCAGTCXXX"       5  "ATG" :del))
 
 (deftest normalize-variant*-test
   (testing "normalize-variant* normalizes variant"


### PR DESCRIPTION
The current version of dbSNP considers deletion of repeat units as repeated sequences, not deletion.

- Current: [NM_004333.5:c.-95_-90GCCTCC[3]](https://www.ncbi.nlm.nih.gov/snp/rs727502907)
- Old: [NM_004333.5:c.-77_-72delGCCTCC](https://www.ncbi.nlm.nih.gov/projects/SNP/snp_ref.cgi?do_not_redirect&rs=rs727502907)

This PR adds support for the repeated sequences caused by deletion on VCF->HGVS conversion.

### 1. Repeated Sequences Caused by Deletion

In the case of DNA mutation, the priority between deletion and repeated sequences is not clearly defined in [HGVS spec](https://varnomen.hgvs.org/), so I added `:prefer-deletion?` option to `vcf-variaht->hgvs` and similar fns for switching conversion behavior.

```clj
(require '[varity.vcf-to-hgvs :as v2h])

(v2h/vcf-variant->coding-dna-hgvs {:chr "chr7", :pos 140924774, :ref "GGGAGGC", :alt "G"}
                                  "path/to/hg38.fa" "path/to/refGene.txt.gz"
                                  {:prefer-deletion? false})
;;=> (#clj-hgvs/hgvs "NM_004333:c.-95GCCTCC[3]")

(v2h/vcf-variant->coding-dna-hgvs {:chr "chr7", :pos 140924774, :ref "GGGAGGC", :alt "G"}
                                  "path/to/hg38.fa" "path/to/refGene.txt.gz"
                                  {:prefer-deletion? true})
;;=> (#clj-hgvs/hgvs "NM_004333:c.-77_-72delGCCTCC")
```

The same applies to protein conversion.

```clj
(v2h/vcf-variant->protein-hgvs {:chr "chr1", :pos 47439008, :ref "CCCGCAC", :alt "C"}
                               "path/to/hg38.fa" "path/to/refGene.txt.gz"
                               {:prefer-deletion? false})
;;=> (#clj-hgvs/hgvs "p.P286_H287[3]")

(v2h/vcf-variant->protein-hgvs {:chr "chr1", :pos 47439008, :ref "CCCGCAC", :alt "C"}
                               "path/to/hg38.fa" "path/to/refGene.txt.gz"
                               {:prefer-deletion? true})
;;=> (#clj-hgvs/hgvs "p.P292_H293del")
```

For backward compatibility, default bahavior of `vcf-variant->hgvs` has not changed, i.e. default `:prefer-deletion?` is `true`.

```clj
(v2h/vcf-variant->coding-dna-hgvs {:chr "chr7", :pos 140924774, :ref "GGGAGGC", :alt "G"}
                                  "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> (#clj-hgvs/hgvs "NM_004333:c.-77_-72delGCCTCC")

(v2h/vcf-variant->protein-hgvs {:chr "chr1", :pos 47439008, :ref "CCCGCAC", :alt "C"}
                               "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> (#clj-hgvs/hgvs "p.P292_H293del")
```

In the case of protein mutation, however, the preference of repeated sequences over deletion is specified in [spec](https://varnomen.hgvs.org/recommendations/protein/variant/repeated/).

> NOTE: when the repeat is variable in the population and the reference sequence has 10 units, the description p.Ala2[9] is preferred over p.Ala11del.

The same is probably true for DNA repeated sequences even though it is not specified. Therefore, I plan to change the default `:prefer-deletion?` to `false` in the next major release (0.7.0).

### 2. Limitation to Repeated Sequences in the Protein Coding Region

This is a kind of bug fix. In the protein coding region of coding DNA HGVS, repeat descriptions must be used only for repeat units with a length which is a multiple of 3 (cf. [repeated#note](https://varnomen.hgvs.org/recommendations/DNA/variant/repeated/#note)).

However, current varity does not consider that.

```clj
;; incorrect (master branch)
(v2h/vcf-variant->coding-dna-hgvs {:chr "chr5", :pos 112839958, :ref "A", :alt "AA"}
                                  "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> (#clj-hgvs/hgvs "NM_001127511:c.4306A[6]"
;;    #clj-hgvs/hgvs "NM_000038:c.4360A[6]"
;;    #clj-hgvs/hgvs "NM_001127510:c.4360A[6]")
```

This PR also includes a fix for that.

```clj
;; correct (PR branch)
(v2h/vcf-variant->coding-dna-hgvs {:chr "chr5", :pos 112839958, :ref "A", :alt "AA"}
                                  "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> (#clj-hgvs/hgvs "NM_001127511:c.4310dupA"
;;    #clj-hgvs/hgvs "NM_000038:c.4364dupA"
;;    #clj-hgvs/hgvs "NM_001127510:c.4364dupA")
```

---

I confirmed `lein test :all` passed.