### PR TITLE
Add prefer-insertion? option to VCF->HGVS

### DIFF
--- a/src/varity/vcf_to_hgvs.clj
+++ b/src/varity/vcf_to_hgvs.clj
@@ -70,6 +70,7 @@
   {;; NOTE: Change default :prefer-deletion to false in the next major release
    ;;       (0.7.0).
    :prefer-deletion? true
+   :prefer-insertion? false
    :tx-margin 5000
    :verbose? false})
 
@@ -89,6 +90,9 @@
                        sequences (e.g. \"c.4_6[1]\"), default true for backward
                        compatibility. The default value plans to be changed to
                        false in the next major release.
+
+    :prefer-insertion? Prefer insertion (e.g. \"c.9_10insAGG\") to repeated
+                       sequences (e.g. \"c.4_6[3]\"), default false.
 
     :tx-margin         The length of transcription margin, up to a maximum of
                        10000, default 5000.
@@ -159,6 +163,9 @@
                        backward compatibility. The default value plans to be
                        changed to false in the next major release.
 
+    :prefer-insertion? Prefer insertion (e.g. \"c.H9_L10insRPH\") to repeated
+                       sequences (e.g. \"c.R4_H6[3]\"), default false.
+
     :verbose?          Print debug information, default false."
   {:arglists '([variant ref-seq ref-gene]
                [variant ref-seq ref-gene options])}
@@ -227,6 +234,9 @@
                        sequences (e.g. \"c.4_6[1]\"), default true for backward
                        compatibility. The default value plans to be changed to
                        false in the next major release.
+
+    :prefer-insertion? Prefer insertion (e.g. \"c.9_10insAGG\") to repeated
+                       sequences (e.g. \"c.4_6[3]\"), default false.
 
     :tx-margin         The length of transcription margin, up to a maximum of
                        10000, default 5000.

--- a/src/varity/vcf_to_hgvs/coding_dna.clj
+++ b/src/varity/vcf_to_hgvs/coding_dna.clj
@@ -68,7 +68,7 @@
       :reverse (repeat-info-backward seq-rdr rg pos alt type))))
 
 (defn- mutation-type
-  [seq-rdr rg pos ref alt {:keys [prefer-deletion?]}]
+  [seq-rdr rg pos ref alt {:keys [prefer-deletion? prefer-insertion?]}]
   (if (re-matches #"[acgntACGNT]*" alt)
     (let [[ref-only alt-only offset _] (diff-bases ref alt)
           nrefo (count ref-only)
@@ -78,6 +78,7 @@
       (cond
         (or (= nrefo nalto 0) (= nrefo nalto 1)) :substitution
         (and prefer-deletion? (pos? nrefo) (zero? nalto)) :deletion
+        (and prefer-insertion? (zero? nrefo) (pos? nalto)) :insertion
         (= ref-only (util-seq/revcomp alt-only)) :inversion
         (and (some? unit) (= ref-repeat 1) (= alt-repeat 2)) :duplication
         (and (some? unit) (pos? alt-repeat)

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -133,7 +133,7 @@
 (defn- ->protein-variant
   [{:keys [strand] :as rg} pos ref alt
    {:keys [ref-exon-seq ref-prot-seq alt-exon-seq] :as seq-info}
-   {:keys [prefer-deletion?]}]
+   {:keys [prefer-deletion? prefer-insertion?]}]
   (cond
     (= ref-exon-seq alt-exon-seq)
     {:type :no-effect, :pos 1, :ref nil, :alt nil}
@@ -181,8 +181,9 @@
                                                      :frame-shift)
               (or (and (zero? nprefo) (zero? npalto))
                   (and (= nprefo 1) (= npalto 1))) :substitution
-              (and (some? unit) (= ref-repeat 1) (= alt-repeat 2)) :duplication
               (and prefer-deletion? (pos? nprefo) (zero? npalto)) :deletion
+              (and prefer-insertion? (zero? nprefo) (pos? npalto)) :insertion
+              (and (some? unit) (= ref-repeat 1) (= alt-repeat 2)) :duplication
               (and (some? unit) (pos? alt-repeat)) :repeated-seqs
               (and (pos? nprefo) (zero? npalto)) :deletion
               (and (pos? nprefo) (pos? npalto)) (if (= base-ppos 1)

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -131,6 +131,12 @@
         "chr7" 140924774 "GGGAGGC" "G" {:prefer-deletion? false} '("NM_004333:c.-95_-90[3]")
         "chr7" 140924774 "GGGAGGC" "G" {:prefer-deletion? true} '("NM_004333:c.-77_-72delGCCTCC")
 
+        ;; prefer-insertion?, cf. rs2307882 (-)
+        "chr3" 126492636 "C" "CCTCT" {:prefer-insertion? false} '("NM_001165974:c.1690-122_1690-121[3]"
+                                                                  "NM_144639:c.1510-122_1510-121[3]")
+        "chr3" 126492636 "C" "CCTCT" {:prefer-insertion? true} '("NM_001165974:c.1690-121_1690-120insAGAG"
+                                                                 "NM_144639:c.1510-121_1510-120insAGAG")
+
         ;; tx-margin
         "chr5" 1295113 "G" "A" {:tx-margin 5000} '("NM_001193376:c.-124C>T"
                                                    "NM_198253:c.-124C>T")
@@ -219,7 +225,11 @@
                                        e)
         ;; prefer-deletion?, not actual example (+)
         "chr1" 47439008 "CCCGCAC" "C" {:prefer-deletion? false} '("p.P286_H287[3]")
-        "chr1" 47439008 "CCCGCAC" "C" {:prefer-deletion? true} '("p.P292_H293del"))))
+        "chr1" 47439008 "CCCGCAC" "C" {:prefer-deletion? true} '("p.P292_H293del")
+
+        ;; prefer-insertion?, cf. rs3046924 (+)
+        "chr1" 47438996 "T" "TCCGCAC" {:prefer-insertion? false} '("p.P286_H287[5]")
+        "chr1" 47438996 "T" "TCCGCAC" {:prefer-insertion? true} '("p.H293_A294insPH"))))
 
   (cavia-testing "throws Exception if inputs are illegal"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]


### PR DESCRIPTION
I added `prefer-insertion?` option to `vcf-variaht->hgvs` and similar fns according to the [previous comment](https://github.com/chrovis/varity/pull/30#pullrequestreview-346676813), which switches the conversion priority of repeated sequences and insertion.

```clj
(require '[varity.vcf-to-hgvs :as v2h])

(v2h/vcf-variant->coding-dna-hgvs {:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"}
                                  "path/to/hg38.fa" "path/to/refGene.txt.gz"
                                  {:prefer-insertion? false})
;;=> (#clj-hgvs/hgvs "NM_001165974:c.1690-122AG[3]"
;;    #clj-hgvs/hgvs "NM_144639:c.1510-122AG[3]")

(v2h/vcf-variant->coding-dna-hgvs {:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"}
                                  "path/to/hg38.fa" "path/to/refGene.txt.gz"
                                  {:prefer-insertion? true})
;;=> (#clj-hgvs/hgvs "NM_001165974:c.1690-121_1690-120insAGAG"
;;    #clj-hgvs/hgvs "NM_144639:c.1510-121_1510-120insAGAG")
```

The same applies to the protein conversion.

```clj
(v2h/vcf-variant->protein-hgvs {:chr "chr1", :pos 47438996, :ref "T", :alt "TCCGCAC"}
                               "path/to/hg38.fa" "path/to/refGene.txt.gz"
                               {:prefer-insertion? false})
;;=> (#clj-hgvs/hgvs "p.P286_H287[5]")

(v2h/vcf-variant->protein-hgvs {:chr "chr1", :pos 47438996, :ref "T", :alt "TCCGCAC"}
                               "path/to/hg38.fa" "path/to/refGene.txt.gz"
                               {:prefer-insertion? true})
;;=> (#clj-hgvs/hgvs "p.H293_A294insPH")
```

I confirmed `lein test :all` passed.