### PR TITLE
Upgrade clj-hgvs and fix cds-start/cds-end handling in vcf-to-hgvs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,8 @@
   :min-lein-version "2.7.0"
   :dependencies [[org.clojure/clojure "1.10.1" :scope "provided"]
                  [org.clojure/tools.logging "0.5.0"]
-                 [clj-hgvs "0.4.0"]
-                 [cljam "0.7.4"]
+                 [clj-hgvs "0.4.3"]
+                 [cljam "0.8.0"]
                  [org.apache.commons/commons-compress "1.19"]
                  [proton "0.1.8"]]
   :plugins [[lein-cloverage "1.1.2"]

--- a/src/varity/vcf_to_hgvs/coding_dna.clj
+++ b/src/varity/vcf_to_hgvs/coding_dna.clj
@@ -136,7 +136,8 @@
               :forward (dec (+ start (count ins)))
               :reverse (inc (- start (count ins))))]
     (mut/dna-duplication (rg/cds-coord start rg)
-                         (rg/cds-coord end rg)
+                         (if-not (= start end)
+                           (rg/cds-coord end rg))
                          (cond-> ins (= strand :reverse) util-seq/revcomp))))
 
 (defn- dna-insertion
@@ -146,7 +147,8 @@
         start (cond-> (+ pos offset) (= strand :forward) dec)
         end (cond-> (+ pos offset) (= strand :reverse) dec)]
     (mut/dna-insertion (rg/cds-coord start rg)
-                       (rg/cds-coord end rg)
+                       (if-not (= start end)
+                         (rg/cds-coord end rg))
                        (cond-> ins (= strand :reverse) util-seq/revcomp))))
 
 (defn- dna-inversion
@@ -162,7 +164,8 @@
               :forward right
               :reverse left)]
     (mut/dna-inversion (rg/cds-coord start rg)
-                       (rg/cds-coord end rg))))
+                       (if-not (= start end)
+                         (rg/cds-coord end rg)))))
 
 ;; e.g. ref alt
 ;;      CAG CTC
@@ -201,7 +204,8 @@
               :forward (dec (+ start nunit))
               :reverse (inc (- start nunit)))]
     (mut/dna-repeated-seqs (rg/cds-coord start rg)
-                           (rg/cds-coord end rg)
+                           (if-not (= start end)
+                             (rg/cds-coord end rg))
                            unit
                            alt-repeat)))
 


### PR DESCRIPTION
When upgrading clj-hgvs to 0.4.3, some vcf-to-hgvs DNA conversions fail because the change (https://github.com/chrovis/clj-hgvs/commit/9a490c86d705efd8eecfafacd9ab439e8a736f30) checks `coord-start` and `coord-end` more strictly.This PR fixes the errors by passing `nil` to `coord-end` if `coord-start` equals `coord-end`.

And I also upgraded cljam to 0.8.0

:ok: `lein test :all` 
:ok: `eastwood` 
:ok: `cljfmt`