### PR TITLE
Seek intron, 3'-UTR, and 5'-UTR regions from genomic position

### DIFF
--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -213,8 +213,6 @@
   ([chr pos rgidx]
    (seek-gene-region chr pos rgidx nil))
   ([chr pos rgidx name]
-   ;; TODO seek intron region
-   ;; TODO seek UTR-5 or UTR-3 region
    (->> (if name
           (ref-genes name rgidx)
           (ref-genes chr pos rgidx))
@@ -245,15 +243,15 @@
                      region-type (let [txs (:tx-start rg)
                                        txe (:tx-end rg)]
                                    (cond
-                                     (< pos txs) (first (sgn '({:type "UTR-5" :idx 0 :count 1}
-                                                               {:type "UTR-3" :idx 0 :count 1})))
-                                     (> pos txe) (second (sgn '({:type "UTR-5" :idx 0 :count 1}
-                                                                {:type "UTR-3" :idx 0 :count 1})))
+                                     (< pos txs) (first (sgn '({:region "UTR-5" :idx 0 :count 1}
+                                                               {:region "UTR-3" :idx 0 :count 1})))
+                                     (> pos txe) (second (sgn '({:region "UTR-5" :idx 0 :count 1}
+                                                                {:region "UTR-3" :idx 0 :count 1})))
                                      :else (if exon-idx
-                                             {:type "exon" :idx exon-idx :count (count exon-ranges)}
-                                             {:type "intron" :idx intron-idx :count (count intron-ranges)})))]
+                                             {:region "exon" :idx exon-idx :count (count exon-ranges)}
+                                             {:region "intron" :idx intron-idx :count (count intron-ranges)})))]
 
-                 {:type (:type region-type) ; "exon", "intron", "UTR-5" or "UTR-3"
+                 {:region (:region region-type) 
                   :index (if (:idx region-type)
                            (inc (:idx region-type))
                            nil)

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -237,18 +237,20 @@
                      intron-idx (->> intron-ranges
                                      (keep-indexed (fn [i [s e]] (if (<= s pos e) i)))
                                      first)
-                     region-type (cond
-                                   (< pos (:tx-start rg)) (first (sgn '({:region "UTR-5" :index 0 :count 1}
-                                                                        {:region "UTR-3" :index 0 :count 1})))
-                                   (> pos (:tx-end rg)) (second (sgn '({:region "UTR-5" :index 0 :count 1}
-                                                                       {:region "UTR-3" :index 0 :count 1})))
+                     utr (cond
+                           (< pos (:cds-start rg)) (first (sgn '({:region "UTR-5" :index 0 :count 1}
+                                                                 {:region "UTR-3" :index 0 :count 1})))
+                           (> pos (:cds-end rg)) (second (sgn '({:region "UTR-5" :index 0 :count 1}
+                                                                {:region "UTR-3" :index 0 :count 1})))
+                           :else nil)
+                     exon-intron (cond
                                    exon-idx {:region "exon" :index exon-idx :count (count exon-ranges)}
-                                   intron-idx {:region "intron" :index intron-idx :count (count intron-ranges)}
-                                   :else nil)]
-                 (-> region-type
-                     (update :index (fn [idx]
-                                      (when idx (inc idx))))
-                     (assoc :gene rg))))))))
+                                   intron-idx {:region "intron" :index intron-idx :count (count intron-ranges)})
+                     region-types (remove nil? (vector utr exon-intron))]
+                 (update {:region-types region-types :gene rg}
+                         :region-types
+                         (partial map #(update % :index (fn [idx]
+                                                          (when idx (inc idx))))))))))))
 
 ;;; Calculation of CDS coordinate
 ;;;

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -211,9 +211,9 @@
 (defn exon-ranges->intron-ranges
   [exon-ranges]
   (loop [intron-ranges []
-         left (first r)
-         right (second r)
-         ranges (rest r)]
+         left (first exon-ranges)
+         right (second exon-ranges)
+         ranges (rest exon-ranges)]
     (if (empty? (first ranges)) intron-ranges
         (recur (conj intron-ranges [(inc (second left)) (dec (first right))])
                right

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -244,13 +244,10 @@
                                                                 {:region "UTR-3"})))
                            :else nil)
                      exon-intron (cond
-                                   exon-idx {:region "exon" :index exon-idx :count (count exon-ranges)}
-                                   intron-idx {:region "intron" :index intron-idx :count (count intron-ranges)})
-                     region-types (remove nil? (vector utr exon-intron))]
-                 (update {:region-types region-types :gene rg}
-                         :region-types
-                         (partial map #(update % :index (fn [idx]
-                                                          (when idx (inc idx))))))))))))
+                                   exon-idx {:region "exon" :index (if exon-idx (inc exon-idx)) :count (count exon-ranges)}
+                                   intron-idx {:region "intron" :index (if intron-idx (inc intron-idx)) :count (count intron-ranges)})
+                     regions (remove nil? (vector utr exon-intron))]
+                 {:regions regions :gene rg}))))))
 
 ;;; Calculation of CDS coordinate
 ;;;

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -231,9 +231,9 @@
                                    (keep-indexed (fn [i [s e]] (if (<= s pos e) i)))
                                    first)
                      intron-ranges (if-not exon-idx
-                                       (->> exon-ranges
-                                            (exon-ranges->intron-ranges)
-                                            (sgn)))
+                                     (->> exon-ranges
+                                          (exon-ranges->intron-ranges)
+                                          (sgn)))
                      intron-idx (->> intron-ranges
                                      (keep-indexed (fn [i [s e]] (if (<= s pos e) i)))
                                      first)

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -245,20 +245,18 @@
                      region-type (let [txs (:tx-start rg)
                                        txe (:tx-end rg)]
                                    (cond
-                                     (< pos txs) (first (sgn '({:type "UTR-5"} {:type "UTR-3"})))
-                                     (> pos txe) (second (sgn '({:type "UTR-5"} {:type "UTR-3"})))
+                                     (< pos txs) (first (sgn '({:type "UTR-5" :idx 0 :count 1}
+                                                               {:type "UTR-3" :idx 0 :count 1})))
+                                     (> pos txe) (second (sgn '({:type "UTR-5" :idx 0 :count 1}
+                                                                {:type "UTR-3" :idx 0 :count 1})))
                                      :else (if exon-idx
                                              {:type "exon" :idx exon-idx :count (count exon-ranges)}
-                                             {:type "intron" :idx intron-idx :count (count intron-ranges)}
-                                             ))
-                                   )]
+                                             {:type "intron" :idx intron-idx :count (count intron-ranges)})))]
 
                  {:type (:type region-type) ; "exon", "intron", "UTR-5" or "UTR-3"
                   :index (if (:idx region-type)
                            (inc (:idx region-type))
                            nil)
-                  :exon-idx exon-idx
-                  :intron-idx intron-idx
                   :count (:count region-type)
                   :gene rg}))))))
 

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -255,8 +255,7 @@
                                    :else nil)]
                  (-> region-type
                      (update :index (fn [idx]
-                                      (if idx (inc idx)
-                                          nil)))
+                                      (when idx (inc idx))))
                      (merge {:gene rg}))))))))
 
 ;;; Calculation of CDS coordinate

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -210,15 +210,9 @@
 
 (defn exon-ranges->intron-ranges
   [exon-ranges]
-  (loop [intron-ranges []
-         left (first exon-ranges)
-         right (second exon-ranges)
-         ranges (rest exon-ranges)]
-    (if (empty? (first ranges)) intron-ranges
-        (recur (conj intron-ranges [(inc (second left)) (dec (first right))])
-               right
-               (second ranges)
-               (rest ranges)))))
+  (mapv (fn [[left right]]
+          [(inc (second left)) (dec (first right))])
+        (partition 2 1 exon-ranges)))
 
 (defn seek-gene-region
   "Seeks chr:pos through exon entries in refGene and returns those indices"

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -210,17 +210,15 @@
 
 (defn exon-ranges->intron-ranges
   [exon-ranges]
-  (->> exon-ranges
-       ((fn [r]
-          (loop [intron-ranges []
-                 left (first r)
-                 right (second r)
-                 ranges (rest r)]
-            (if (empty? (first ranges)) intron-ranges
-                (recur (conj intron-ranges [(inc (second left)) (dec (first right))])
-                       right
-                       (second ranges)
-                       (rest ranges))))))))
+  (loop [intron-ranges []
+         left (first r)
+         right (second r)
+         ranges (rest r)]
+    (if (empty? (first ranges)) intron-ranges
+        (recur (conj intron-ranges [(inc (second left)) (dec (first right))])
+               right
+               (second ranges)
+               (rest ranges)))))
 
 (defn seek-gene-region
   "Seeks chr:pos through exon entries in refGene and returns those indices"

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -238,7 +238,7 @@
                      exon-idx (->> (sgn exon-ranges)
                                    (keep-indexed (fn [i [s e]] (if (<= s pos e) i)))
                                    first)
-                     intron-ranges (if exon-idx nil
+                     intron-ranges (if-not exon-idx
                                        (->> exon-ranges
                                             (exon-ranges->intron-ranges)
                                             (sgn)))

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -256,7 +256,7 @@
                  (-> region-type
                      (update :index (fn [idx]
                                       (when idx (inc idx))))
-                     (merge {:gene rg}))))))))
+                     (assoc :gene rg))))))))
 
 ;;; Calculation of CDS coordinate
 ;;;

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -238,10 +238,10 @@
                                      (keep-indexed (fn [i [s e]] (if (<= s pos e) i)))
                                      first)
                      utr (cond
-                           (< pos (:cds-start rg)) (first (sgn '({:region "UTR-5" :index 0 :count 1}
-                                                                 {:region "UTR-3" :index 0 :count 1})))
-                           (> pos (:cds-end rg)) (second (sgn '({:region "UTR-5" :index 0 :count 1}
-                                                                {:region "UTR-3" :index 0 :count 1})))
+                           (< pos (:cds-start rg)) (first (sgn '({:region "UTR-5"}
+                                                                 {:region "UTR-3"})))
+                           (> pos (:cds-end rg)) (second (sgn '({:region "UTR-5"}
+                                                                {:region "UTR-3"})))
                            :else nil)
                      exon-intron (cond
                                    exon-idx {:region "exon" :index exon-idx :count (count exon-ranges)}

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -194,10 +194,10 @@
 (deftest exon-ranges->intron-ranges-test
   (testing "exon-ranges->intron-ranges"
     (are [exon-ranges r] (= r (rg/exon-ranges->intron-ranges exon-ranges))
-             [] []
-             [[1 10] [20 30]] [[11 19]]
-             [[1000 2000] [3000 3500] [5000 6000]] [[2001 2999] [3501 4999]]
-             [[100 300]] [])))
+      [] []
+      [[1 10] [20 30]] [[11 19]]
+      [[1000 2000] [3000 3500] [5000 6000]] [[2001 2999] [3501 4999]]
+      [[100 300]] [])))
 
 (defslowtest seek-gene-region-test
   (cavia-testing "seek-gene-region (slow)"
@@ -215,7 +215,7 @@
         "chr5" 12575053 nil [[["UTR-5" nil nil] ["intron" 1 3]]]
         "chr10" 79512600 "NM_001099692" [[["UTR-5" nil nil]]]
         "chr12" 101128642 "NM_001286615" [[["UTR-3" nil nil]] [["UTR-5" nil nil]]]
-        ))))
+        "chr7" 140753336 "NM_004333" [[["exon" 15 18]]]))))
 
 (deftest cds-coord-test
   ;; 1 [2 3 4] 5 6 7 [8 9 10 11] 12 13 14 15

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -191,12 +191,20 @@
           "NM_019063" "ATGGAC" "TCCTAA" 2946
           "NM_004304" "ATGGGA" "CCCTGA" 4863)))))
 
+(deftest exon-ranges->intron-ranges-test
+  (testing "exon-ranges->intron-ranges"
+    (are [exon-ranges r] (= r (rg/exon-ranges->intron-ranges exon-ranges))
+             [] []
+             [[1 10] [20 30]] [[11 19]]
+             [[1000 2000] [3000 3500] [5000 6000]] [[2001 2999] [3501 4999]]
+             [[100 300]] [])))
+
 (defslowtest seek-gene-region-test
   (cavia-testing "seek-gene-region (slow)"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [c p tn exs] (= exs
                            (->> (rg/seek-gene-region c p rgidx tn)
-                                (map #(vector (:type %) (:index %) (:count %)))))
+                                (map #(vector (:region %) (:index %) (:count %)))))
         "chr4" 54736520 nil [["exon" 18 21] ["exon" 18 21]]
         "chr7" 116771976 "NM_000245" [["exon" 14 21]]
         "chrX" 61197987 nil []

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -204,7 +204,7 @@
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [c p tn exs] (= exs
                            (->> (rg/seek-gene-region c p rgidx tn)
-                                (map :region-types)
+                                (map :regions)
                                 (mapv (fn [rt]
                                         (mapv #(vector (:region %) (:index %) (:count %))
                                               rt)))))
@@ -212,9 +212,9 @@
         "chr7" 116771976 "NM_000245" [[["exon" 14 21]]]
         "chrX" 61197987 nil []
         "chr3" 41224090 "NM_001904" [[["intron" 2 14]]]
-        "chr5" 12575053 nil [[["UTR-5" 1 1] ["intron" 1 3]]]
-        "chr10" 79512600 "NM_001099692" [[["UTR-5" 1 1]]]
-        "chr12" 101128642 "NM_001286615" [[["UTR-3" 1 1]] [["UTR-5" 1 1]]]
+        "chr5" 12575053 nil [[["UTR-5" nil nil] ["intron" 1 3]]]
+        "chr10" 79512600 "NM_001099692" [[["UTR-5" nil nil]]]
+        "chr12" 101128642 "NM_001286615" [[["UTR-3" nil nil]] [["UTR-5" nil nil]]]
         ))))
 
 (deftest cds-coord-test

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -197,10 +197,13 @@
       (are [c p tn exs] (= exs
                            (->> (rg/seek-gene-region c p rgidx tn)
                                 (map #(vector (:exon-index %) (:exon-count %)))))
-        "chr4" 54736520   nil        [[18 21] [18 21]]
-        "chr7" 116771976 "NM_000245" [[14 21]]
-        "chrX" 61197987   nil        []
-        "chr3" 41217131  "NM_001904" [[nil 15]]))))
+        "chr4" 54736520 nil [["exon" 18 21] ["exon" 18 21]]
+        "chr7" 116771976 "NM_000245" [["exon" 14 21]]
+        "chrX" 61197987 nil []
+        "chr3" 41217131 "NM_001904" [["intron" 1 14]]
+        "chr5" 12575053 nil [["intron" 1 3]]
+        "chr10" 79512600 "NM_001099692" [["UTR-5" 1 1]]
+        "chr12" 101128642 "NM_001286615" [["UTR-3" 1 1] ["UTR-5" 1 1]]))))
 
 (deftest cds-coord-test
   ;; 1 [2 3 4] 5 6 7 [8 9 10 11] 12 13 14 15

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -203,7 +203,7 @@
   (cavia-testing "seek-gene-region (slow)"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [c p tn exs] (= exs
-                           (->> (seek-gene-region c p rgidx tn)
+                           (->> (rg/seek-gene-region c p rgidx tn)
                                 (map :region-types)
                                 (mapv (fn [rt]
                                         (mapv #(vector (:region %) (:index %) (:count %))
@@ -214,7 +214,8 @@
         "chr3" 41224090 "NM_001904" [[["intron" 2 14]]]
         "chr5" 12575053 nil [[["UTR-5" 1 1] ["intron" 1 3]]]
         "chr10" 79512600 "NM_001099692" [[["UTR-5" 1 1]]]
-        "chr12" 101128642 "NM_001286615" [[["UTR-3" 1 1]] [["UTR-5" 1 1]]]))))
+        "chr12" 101128642 "NM_001286615" [[["UTR-3" 1 1]] [["UTR-5" 1 1]]]
+        ))))
 
 (deftest cds-coord-test
   ;; 1 [2 3 4] 5 6 7 [8 9 10 11] 12 13 14 15

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -203,15 +203,18 @@
   (cavia-testing "seek-gene-region (slow)"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [c p tn exs] (= exs
-                           (->> (rg/seek-gene-region c p rgidx tn)
-                                (map #(vector (:region %) (:index %) (:count %)))))
-        "chr4" 54736520 nil [["exon" 18 21] ["exon" 18 21]]
-        "chr7" 116771976 "NM_000245" [["exon" 14 21]]
+                           (->> (seek-gene-region c p rgidx tn)
+                                (map :region-types)
+                                (mapv (fn [rt]
+                                        (mapv #(vector (:region %) (:index %) (:count %))
+                                              rt)))))
+        "chr4" 54736520 nil [[["exon" 18 21]] [["exon" 18 21]]]
+        "chr7" 116771976 "NM_000245" [[["exon" 14 21]]]
         "chrX" 61197987 nil []
-        "chr3" 41217131 "NM_001904" [["intron" 1 14]]
-        "chr5" 12575053 nil [["intron" 1 3]]
-        "chr10" 79512600 "NM_001099692" [["UTR-5" 1 1]]
-        "chr12" 101128642 "NM_001286615" [["UTR-3" 1 1] ["UTR-5" 1 1]]))))
+        "chr3" 41224090 "NM_001904" [[["intron" 2 14]]]
+        "chr5" 12575053 nil [[["UTR-5" 1 1] ["intron" 1 3]]]
+        "chr10" 79512600 "NM_001099692" [[["UTR-5" 1 1]]]
+        "chr12" 101128642 "NM_001286615" [[["UTR-3" 1 1]] [["UTR-5" 1 1]]]))))
 
 (deftest cds-coord-test
   ;; 1 [2 3 4] 5 6 7 [8 9 10 11] 12 13 14 15

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -196,7 +196,7 @@
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [c p tn exs] (= exs
                            (->> (rg/seek-gene-region c p rgidx tn)
-                                (map #(vector (:exon-index %) (:exon-count %)))))
+                                (map #(vector (:type %) (:index %) (:count %)))))
         "chr4" 54736520 nil [["exon" 18 21] ["exon" 18 21]]
         "chr7" 116771976 "NM_000245" [["exon" 14 21]]
         "chrX" 61197987 nil []


### PR DESCRIPTION
The seek-gene-region function can return Intron and UTR.

I'm trying to split the key `:exon-foo` into `:type` and `:foo` .
 - The value of `:type` is a region type such as 'exon',  'intron', etc ...
 - The value of `:foo` is conventional (index, count, etc.)