### PR TITLE
Error handling in conversion of an invalid coordinate

### DIFF
--- a/src/varity/hgvs_to_vcf.clj
+++ b/src/varity/hgvs_to_vcf.clj
@@ -20,7 +20,14 @@
 
 (defn- coding-dna-hgvs->vcf-variants
   [hgvs seq-rdr rgs]
-  (distinct (keep #(coding-dna/->vcf-variant hgvs seq-rdr %) rgs)))
+  (distinct
+   (keep (fn [rg]
+           (try
+             (coding-dna/->vcf-variant hgvs seq-rdr rg)
+             (catch Exception e
+               (when-not (= (:type (ex-data e)) ::rg/invalid-coordinate)
+                 (throw e)))))
+         rgs)))
 
 (defn- protein-hgvs->vcf-variants
   [hgvs seq-rdr rgs]

--- a/test/varity/hgvs_test.clj
+++ b/test/varity/hgvs_test.clj
@@ -1,5 +1,5 @@
 (ns varity.hgvs-test
-  (:require [clojure.test :refer [are]]
+  (:require [clojure.test :refer [are testing]]
             [clj-hgvs.core :as hgvs]
             [cljam.io.sequence :as cseq]
             [varity.hgvs :as vhgvs]
@@ -56,4 +56,12 @@
           "NM_144639:c.1510-122AG[3]" (find-rg "NM_144639") #{"NM_144639:c.1510-122AG[3]"
                                                               "NM_144639:c.1510-121_1510-120insAGAG"}
           "NM_144639:c.1510-121_1510-120insAGAG" (find-rg "NM_144639") #{"NM_144639:c.1510-122AG[3]"
-                                                                         "NM_144639:c.1510-121_1510-120insAGAG"})))))
+                                                                         "NM_144639:c.1510-121_1510-120insAGAG"})
+
+        (testing "false coordinate"
+          (are [s] (thrown-with-error-type?
+                    ::vhgvs/invalid-variant
+                    (vhgvs/find-aliases (hgvs/parse s) rdr rgidx))
+            "NM_001276760:c.559+1G>T" ; actually "NM_001276760:c.560G>T"
+            "NM_005228:c.2574-1T>G" ; actually "NM_005228:c.2573T>G"
+            ))))))

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -44,7 +44,6 @@
         "NM_005228:c.2571GCT[3]" '({:chr "chr7", :pos 55191819, :ref "G", :alt "GGCTGCT"})
         "NM_144639:c.1510-122_1510-121[3]" '({:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"}) ; cf. rs2307882 (-)
         "NM_144639:c.1510-122AG[3]" '({:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"})
-        "NM_004369:c.6063+6[9]" '({:chr "chr2", :pos 237363239, :ref "T", :alt "TA"}) ; cf. rs11385011 (-)
         "NM_000059:c.18AG[2]" '({:chr "chr13", :pos 32316477, :ref "AAG", :alt "A"}) ; cf. rs397507623 (+)
         "NM_004333:c.-95_-90[3]" '({:chr "chr7", :pos 140924774, :ref "GGGAGGC", :alt "G"}) ; cf. rs727502907 (-)
         )))
@@ -88,8 +87,6 @@
         "c.2571GCT[3]" "EGFR" '({:chr "chr7", :pos 55191819, :ref "G", :alt "GGCTGCT"})
         "c.1510-122_1510-121[3]" "UROC1" '({:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"}) ; cf. rs2307882 (-)
         "c.1510-122AG[3]" "UROC1" '({:chr "chr3", :pos 126492636, :ref "C", :alt "CCTCT"})
-        "c.6063+6[9]" "COL6A3" '({:chr "chr2", :pos 237363239, :ref "T", :alt "TA"}
-                                 {:chr "chr2", :pos 237353343, :ref "G", :alt "GTTTTTTTT"}) ; cf. rs11385011 (-)
         "c.18AG[2]" "BRCA2" '({:chr "chr13", :pos 32316477, :ref "AAG", :alt "A"}) ; cf. rs397507623 (+)
         "c.-95_-90[3]" "BRAF" '({:chr "chr7", :pos 140924774, :ref "GGGAGGC", :alt "G"}) ; cf. rs727502907 (-)
         )))

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -320,4 +320,20 @@
       "-2+1" 2 3  7
       "*2-1" 9 11 5
       "-7"   2 3  13
-      "*5"   9 11 1)))
+      "*5"   9 11 1))
+  (testing "false coordinate"
+    (are [c s] (thrown-with-error-type?
+                ::rg/invalid-coordinate
+                (rg/cds-coord->genomic-pos (coord/parse-coding-dna-coordinate c)
+                                           {:strand s
+                                            :cds-start 2
+                                            :cds-end 11
+                                            :exon-ranges [[2 4] [8 11]]}))
+      "2+1" :forward
+      "5-1" :forward
+      "4+1" :forward
+      "3-1" :forward
+      "2-1" :reverse
+      "5+1" :reverse
+      "4-1" :reverse
+      "3+1" :reverse)))


### PR DESCRIPTION
This PR makes the conversion from a CDS coordinate to a genomic position strict.

Current `varity.ref-gene/cds-coord->genomic-pos` can convert a false intron coordinate to a genomic position.

```clj
(require '[varity.ref-gene :as rg]
         '[clj-hgvs.coordinate :as coord])

(rg/cds-coord->genomic-pos (coord/parse-coding-dna-coordinate "2+1")
                           {:strand :forward
                            :cds-start 2
                            :cds-end 11
                            :exon-ranges [[2 4] [8 11]]})
;;=> 3
```

In the above example, though the genomic position `3` is in the exon (`[2 4]`), the CDS coordinate `2+1` represents the intron position. This causes `varity.hgvs/find-aliases` to find incorrect aliases.

```clj
(require '[varity.hgvs :as vhgvs])

;; correct -  NM_000059:c.162CAA[1]
(vhgvs/find-aliases #clj-hgvs/hgvs "NM_000059:c.162CAA[1]" "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> (#clj-hgvs/hgvs "NM_000059:c.162CAA[1]" ; <- same as the inputted HGVS
;;    #clj-hgvs/hgvs "NM_000059:c.165_167delCAA")

;; incorrect - NM_000059:c.161+1CAA[1]
(vhgvs/find-aliases #clj-hgvs/hgvs "NM_000059:c.161+1CAA[1]" "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> (#clj-hgvs/hgvs "NM_000059:c.162CAA[1]" ; <- different from the inputted HGVS
;;    #clj-hgvs/hgvs "NM_000059:c.165_167delCAA")
```

This PR makes `varity.ref-gene/cds-coord->genomic-pos` throw an exception when the invalid CDS coordinate is supplied.

```clj
(rg/cds-coord->genomic-pos (coord/parse-coding-dna-coordinate "2+1")
                           {:strand :forward
                            :cds-start 2
                            :cds-end 11
                            :exon-ranges [[2 4] [8 11]]})
;;=> Execution error (ExceptionInfo) at varity.ref-gene/cds-coord->genomic-pos (ref_gene.clj:358).
;;   The coordinate is invalid for the refGene.
```

`varity.hgvs/find-aliases` also throws the exception when the inputted HGVS is wrong.

```clj
(vhgvs/find-aliases #clj-hgvs/hgvs "NM_000059:c.161+1CAA[1]" "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> Execution error (ExceptionInfo) at varity.hgvs/eval17743$fn (hgvs.clj:68).
;;   The VCF variant is not found.
```

I confirmed `lein test :all` passed.