### PR TITLE
changed the return format: vector->map

### DIFF
--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -245,9 +245,9 @@
                            :else nil)
                      exon-intron (cond
                                    exon-idx {:region "exon" :index (if exon-idx (inc exon-idx)) :count (count exon-ranges)}
-                                   intron-idx {:region "intron" :index (if intron-idx (inc intron-idx)) :count (count intron-ranges)})
-                     regions (remove nil? (vector utr exon-intron))]
-                 {:regions regions :gene rg}))))))
+                                   intron-idx {:region "intron" :index (if intron-idx (inc intron-idx)) :count (count intron-ranges)})]
+                 {:regions {:utr utr :exon-intron exon-intron}
+                  :gene rg}))))))
 
 ;;; Calculation of CDS coordinate
 ;;;

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -204,10 +204,11 @@
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [c p tn exs] (= exs
                            (->> (rg/seek-gene-region c p rgidx tn)
-                                (map :regions)
+                                (mapv #(vector (get-in % [:regions :utr]) (get-in % [:regions :exon-intron])))
                                 (mapv (fn [rt]
                                         (mapv #(vector (:region %) (:index %) (:count %))
-                                              rt)))))
+                                              rt)))
+                                (mapv #(remove (partial every? nil?) %))))
         "chr4" 54736520 nil [[["exon" 18 21]] [["exon" 18 21]]]
         "chr7" 116771976 "NM_000245" [[["exon" 14 21]]]
         "chrX" 61197987 nil []


### PR DESCRIPTION
To address region overlapping, I changed the format of gene regions from vector to associative.

before:
```clojure
{:regions
 [utr-region
  exon-intron-region]}
```
after:
```clojure
{:regions
 {:utr utr-region
  :exon-intron exon-intron-region}}
```