### PR TITLE
Fix reference protein seq in fs-ter-substitution

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -194,7 +194,12 @@
       {:type (if (= t :fs-ter-substitution) :substitution t)
        :pos base-ppos
        :ref (if (= t :fs-ter-substitution)
-              (str pref (subs ref-prot-rest 0 (max 0 (inc (- (count palt) (count pref))))))
+              (let [pref-len (count pref)
+                    palt-len (count palt)
+                    palt-ter-len (inc palt-len)]
+                (if (<= pref-len palt-ter-len)
+                  (str pref (subs ref-prot-rest 0 (max 0 (inc (- palt-len pref-len)))))
+                  (subs pref 0 palt-ter-len)))
               pref)
        :alt (if (= t :fs-ter-substitution)
               (str palt \*)

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -198,7 +198,7 @@
                     palt-len (count palt)
                     palt-ter-len (inc palt-len)]
                 (if (<= pref-len palt-ter-len)
-                  (str pref (subs ref-prot-rest 0 (max 0 (inc (- palt-len pref-len)))))
+                  (str pref (subs ref-prot-rest 0 (inc (- palt-len pref-len))))
                   (subs pref 0 palt-ter-len)))
               pref)
        :alt (if (= t :fs-ter-substitution)

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -170,6 +170,8 @@
         "chr7" 152247986 "G" "GT" '("p.Y816*") ; cf. rs150073007 (-, nonsense mutation)
         "chr17" 31159027 "TGC" "T" '("p.A75*") ; not actual example (+, nonsense in del case)
         "chr2" 47478341 "TG" "T" '("p.L762*" "p.L696*") ;; rs786204050 (+) frameshift with termination
+        "chr8" 42838217 "GAGATTAACAGGGGTCTGAAGAGGCGGCATTAGTAATCCAATAGCAGCATCAACCTGGGAAACAGGAGGCGGTAAAGGAGGTGGGGGAAGCTGTTCCTGTGGCTCCAGAAGATCTTCTTTCTAAAACAAAAATACAAAGTATGTTTGAATTTAGTAACTAAAAACAGTTTAAA" "G"
+        '("p.K90Lfs*5" "p.K25*") ; cf. VCV000965170.1 (-, frameshift with termination)
 
         ;; deletion
         "chr1" 240092288 "AGTC" "A" '("p.S61del") ; cf. rs772088733 (+)


### PR DESCRIPTION
This PR fixes the assert error that is occured if returning [`:ref`](https://github.com/chrovis/varity/blob/7f5eb026108c05f4a37270d79a767f17d4e1a848/src/varity/vcf_to_hgvs/protein.clj#L196) contains stop symbol, '*', at the end.

[VCV000965170.1](https://www.ncbi.nlm.nih.gov/clinvar/variation/965170) is a one of example case to cause this.

You can reproduce this problem like below steps:

```clojure
(require ['varity.hgvs-to-vcf :as 'h2v]
         ['varity.vcf-to-hgvs :as 'v2h]
         ['clj-hgvs.core :as 'clj-hgvs])

(h2v/hgvs->vcf-variants (clj-hgvs/parse "NM_199003.1:c.72-53_*28del") "/path/to/hg38.fa" "/path/to/hg38/20200818015652/refGene.txt.gz")
;; =>
;; ({:chr "chr8",
;;   :pos 42838217,
;;   :ref "GAGATTAACAGGGGTCTGAAGAGGCGGCATTAGTAATCCAATAGCAGCATCAACCTGGGAAACAGGAGGCGGTAAAGGAGGTGGGGGAAGCTGTTCCTGTGGCTCCAGAAGATCTTCTTTCTAAAACAAAAATACAAAGTATGTTTGAATTTAGTAACTAAAAACAGTTTAAA",
;;   :alt "G"})

(v2h/vcf-variant->hgvs (first *1) "/path/to/hg38.fa" "/path/to/hg38/20200818015652/refGene.txt.gz" {:verbose? true})
;;  variant: {:chr "chr8", :pos 42838217, :ref "GAGATTAACAGGGGTCT...", :alt "G"}
;; ref-gene: {:name "NM_199003", :name2 "THAP1", :strand :reverse}
;; 
;;              42838201  42838211  42838221  42838231  42838241  42838251  42838261  42838271  42838281  42838291  42838301  42838311  42838321  42838331  42838341  42838351  42838361  42838371  42838381  42838391  42838401
;;     ref: TTGTGGTCACAGAAAACTGAGAGATTAACAGGGGTCTGAAGAGGCGGCATTAGTAATCCAATAGCAGCATCAACCTGGGAAACAGGAGGCGGTAAAGGAGGTGGGGGAAGCTGTTCCTGTGGCTCCAGAAGATCTTCTTTCTAAAACAAAAATACAAAGTATGTTTGAATTTAGTAACTAAAAACAGTTTAAAAGAATCTGTGGACTGACCAG
;;     alt: TTGTGGTCACAGAAAACTGAG                                                                                                                                                                            AGAATCTGTGGACTGACCAG
;;                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
;; 
;;                   72-65     72-55     72-45     72-35     72-25     72-15     72-5      77        87        97        107       117       127       137       147       157       *5        *15       *25       *35       *45
;;   c.ref: cctggtcagtccacagattcttttaaactgtttttagttactaaattcaaacatactttgtatttttgttttagAAAGAAGATCTTCTGGAGCCACAGGAACAGCTTCCCCCACCTCCTTTACCGCCTCCTGTTTCCCAGGTTGATGCTGCTATTGGATTACTAATGCCGCCTCTTCAGACCCCTGTTAATCTCTCAGTTTTCTGTGACCACAA
;;   c.alt: cctggtcagtccacagattct                                                                                                                                                                            CTCAGTTTTCTGTGACCACAA
;;                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
;; 
;;                 11        21        31        41
;;   p.ref: SCSAYGCKNRYDKDKPVSFHKKKIFWSHRNSFPHLLYRLLFPRLMLLLDY*
;;   p.alt: SCSAYGCKNRYDKDKPVSFHK*GPCAPRGAVPPLQTPVNLS
;;                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
;; Execution error (AssertionError) at clj-hgvs.mutation/protein-substitution (mutation.cljc:1584).
;; Assert failed: (intl/valid? :clj-hgvs.mutation/protein-substitution %)
```

So I fixed this issue by trimming `:ref`, that is returned caller, with returning `:alt`'s length. In the above case, "KK" for `:ref`, "K*" for `:alt`.

Now, `vcf-variant-hgvs` should returns following HGVS instances:

```clojure
({:coding-dna #clj-hgvs/hgvs"NM_199003:c.72-53_*28delTTTAAACTGTTTTTAGTTACTAAATTCAAACATACTTTGTATTTTTGTTTTAGAAAGAAGATCTTCTGGAGCCACAGGAACAGCTTCCCCCACCTCCTTTACCGCCTCCTGTTTCCCAGGTTGATGCTGCTATTGGATTACTAATGCCGCCTCTTCAGACCCCTGTTAATCT",
  :protein #clj-hgvs/hgvs"p.K25*"}
 {:coding-dna #clj-hgvs/hgvs"NM_018105:c.268-53_386delTTTAAACTGTTTTTAGTTACTAAATTCAAACATACTTTGTATTTTTGTTTTAGAAAGAAGATCTTCTGGAGCCACAGGAACAGCTTCCCCCACCTCCTTTACCGCCTCCTGTTTCCCAGGTTGATGCTGCTATTGGATTACTAATGCCGCCTCTTCAGACCCCTGTTAATCT",
  :protein #clj-hgvs/hgvs"p.K90Lfs*5"})
```

I confirmed `lein test :all` passed.