### PR TITLE
Lookup index by GENCODE

### DIFF
--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -248,7 +248,7 @@
   "Searches refGene entries with ref-seq, gene or (chr, pos) using index,
   returning results as sequence. See also varity.ref-gene/index."
   ([s rgidx]
-   (get-in rgidx (if (re-find #"^(NC|LRG|NG|NM|NR|NP)_" s)
+   (get-in rgidx (if (re-find #"^ENST|^(NC|LRG|NG|NM|NR|NP)_" s)
                    [:ref-seq s]
                    [:gene s])))
   ([chr pos rgidx] (ref-genes chr pos rgidx 0))

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -111,7 +111,7 @@
                            (merge base
                                   {:name t-id
                                    :name2 (get attribute "gene_name")
-                                   :gene_id (get attribute "gene_id")
+                                   :gene-id (get attribute "gene_id")
                                    :strand (:strand gtf)
                                    :score (:score gtf)}))
 

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -141,6 +141,32 @@
         (is (= output
                (rg/cds-seq parsed-gtf-region)))))))
 
+(deftest ref-genes-test
+  (let [gencode-test-data [{:name2 "C11orf68"
+                            :name "ENST00000449692.3"
+                            :tx-start 65916810
+                            :tx-end 65919062
+                            :chr "chr11"}
+                           {:name2 "KRAS"
+                            :name "ENST00000311936.8"
+                            :tx-start 25205246
+                            :tx-end 25250929
+                            :chr "chr12"}
+                           {:name2 "KRAS"
+                            :name "ENSP00000000001.8"
+                            :tx-start 25205246
+                            :tx-end 25250929
+                            :chr "chr12"}]
+        gencode-idx (rg/index gencode-test-data)]
+    (are [?param ?output]
+        (= (-> (rg/ref-genes ?param gencode-idx) first :name)
+           ?output)
+      "ENST00000449692.3" "ENST00000449692.3"
+      "KRAS" "ENST00000311936.8"
+
+      "FOO" nil
+      "ENSP00000000001.8" nil)))
+
 (defslowtest regions-slow
   (cavia-testing "exon-seq"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -159,13 +159,13 @@
                             :chr "chr12"}]
         gencode-idx (rg/index gencode-test-data)]
     (are [?param ?output]
-        (= (-> (rg/ref-genes ?param gencode-idx) first :name)
+        (= (map :name (rg/ref-genes ?param gencode-idx))
            ?output)
-      "ENST00000449692.3" "ENST00000449692.3"
-      "KRAS" "ENST00000311936.8"
+      "ENST00000449692.3" ["ENST00000449692.3"]
+      "KRAS" ["ENST00000311936.8" "ENSP00000000001.8"]
 
-      "FOO" nil
-      "ENSP00000000001.8" nil)))
+      "FOO" '()
+      "ENSP00000000001.8" '())))
 
 (defslowtest regions-slow
   (cavia-testing "exon-seq"


### PR DESCRIPTION
- [previous ref-gene implementation](https://github.com/chrovis/varity/pull/42) lacks support to look up regions by GENCODE id

