### PR TITLE
feat: conversion from/to hgvs with GENCODE ID

### DIFF
--- a/src/varity/hgvs_to_vcf.clj
+++ b/src/varity/hgvs_to_vcf.clj
@@ -33,9 +33,9 @@
   [hgvs seq-rdr rgs]
   (distinct (apply concat (keep #(prot/->vcf-variants hgvs seq-rdr %) rgs))))
 
-(defn- ->supported-transcript
+(defn- supported-transcript?
   [s]
-  (re-find #"^((NM|NR)_|ENS(T|P))\d+(\.\d+)?$" s))
+  (some? (re-matches #"^((NM|NR)_|ENS(T|P))\d+(\.\d+)?$" (str s))))
 
 (defmulti hgvs->vcf-variants
   "Converts coding DNA/protein hgvs into possible VCF-style variants. Transcript of
@@ -70,8 +70,8 @@
                    (throw (ex-info "supported HGVS kinds are only `:coding-dna` and `:protein`"
                                    {:type ::unsupported-hgvs-kind
                                     :hgvs-kind kind})))
-         rgs (if-let [[rs] (->supported-transcript (str transcript))]
-               (rg/ref-genes rs rgidx)
+         rgs (if (supported-transcript? transcript)
+               (rg/ref-genes (str transcript))
                (if-not (string/blank? gene)
                  (rg/ref-genes gene rgidx)
                  (throw (ex-info "Transcript (NM_, NR_, ENST, ENSP) or gene must be supplied."

--- a/src/varity/hgvs_to_vcf.clj
+++ b/src/varity/hgvs_to_vcf.clj
@@ -35,7 +35,7 @@
 
 (defn- supported-transcript?
   [s]
-  (some? (re-matches #"^((NM|NR)_|ENS(T|P))\d+(\.\d+)?$" (str s))))
+  (some? (re-matches #"((NM|NR)_|ENS(T|P))\d+(\.\d+)?" (str s))))
 
 (defmulti hgvs->vcf-variants
   "Converts coding DNA/protein hgvs into possible VCF-style variants. Transcript of
@@ -71,7 +71,7 @@
                                    {:type ::unsupported-hgvs-kind
                                     :hgvs-kind kind})))
          rgs (if (supported-transcript? transcript)
-               (rg/ref-genes (str transcript))
+               (rg/ref-genes (str transcript) rgidx)
                (if-not (string/blank? gene)
                  (rg/ref-genes gene rgidx)
                  (throw (ex-info "Transcript (NM_, NR_, ENST, ENSP) or gene must be supplied."

--- a/src/varity/vcf_to_hgvs.clj
+++ b/src/varity/vcf_to_hgvs.clj
@@ -27,7 +27,7 @@
       (map? ref-gene) :ref-gene-entity)))
 
 (defn- coding-dna-ref-gene? [rg]
-  (some? (re-matches #"NM_\d+(\.\d+)?" (:name rg))))
+  (some? (re-matches #"(NM_|ENST)\d+(\.\d+)?" (:name rg))))
 
 (defn select-variant
   [var seq-rdr rg]

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -14,10 +14,9 @@
                                      test-ref-seq-file]]
             [varity.vcf-to-hgvs :as v2h]))
 
-(deftest ->supported-transcript-test
+(deftest supported-transcript?-test
   (testing "supported transcript"
-    (are [transcript] (= (first (#'h2v/->supported-transcript transcript))
-                         transcript)
+    (are [transcript] (true? (#'h2v/supported-transcript? transcript))
       "NM_001.3"
       "NM_112"
       "NR_001.4"
@@ -28,7 +27,7 @@
       "ENSP0001"
       "ENSP0001.11"))
   (testing "unsupported transcript"
-    (are [transcript] (nil? (first (#'h2v/->supported-transcript transcript)))
+    (are [transcript] (false? (#'h2v/supported-transcript? transcript))
       "xNM_001.3"
       "NM001"
       "NM3.3"

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -14,6 +14,36 @@
                                      test-ref-seq-file]]
             [varity.vcf-to-hgvs :as v2h]))
 
+(deftest ->supported-transcript-test
+  (testing "supported transcript"
+    (are [transcript] (= (first (#'h2v/->supported-transcript transcript))
+                         transcript)
+      "NM_001.3"
+      "NM_112"
+      "NR_001.4"
+      "NR_002"
+
+      "ENST00000497784.2"
+      "ENST00000497784"
+      "ENSP0001"
+      "ENSP0001.11"))
+  (testing "unsupported transcript"
+    (are [transcript] (nil? (first (#'h2v/->supported-transcript transcript)))
+      "xNM_001.3"
+      "NM001"
+      "NM3.3"
+      "NM_.3"
+      "NM_"
+      "NR"
+      "NMR_3.3"
+      "XM_024451963.1"
+
+      "ENST"
+      "ENSP"
+      "ENSTP001"
+
+      "NM_111.1ENST001.1")))
+
 (defslowtest hgvs->vcf-variants-test
   (cavia-testing "coding DNA HGVS to vcf variants"
     (let [ref-gene-idx (rg/index (rg/load-ref-genes test-ref-gene-file))]

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -245,13 +245,13 @@
 
 (deftest coding-dna-ref-gene?-test
   (testing "valid reference genes"
-    (are [transcript] (#'v2h/coding-dna-ref-gene? {:name transcript})
+    (are [transcript] (true? (#'v2h/coding-dna-ref-gene? {:name transcript}))
       "NM_001005484.2"
       "NM_001005484"
       "ENST00000644969.2"
       "ENST00000644969"))
   (testing "invalid reference genes"
-    (are [transcript] (not (#'v2h/coding-dna-ref-gene? {:name transcript}))
+    (are [transcript] (false? (#'v2h/coding-dna-ref-gene? {:name transcript}))
       "XM_024451963.1"
       "XM_024451963"
       "NR_024540.1"

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [clj-hgvs.core :as hgvs]
             [varity.ref-gene :as rg]
-            [varity.vcf-to-hgvs :refer :all]
+            [varity.vcf-to-hgvs :refer :all :as v2h]
             [varity.t-common :refer [test-ref-seq-file
                                      test-ref-gene-file
                                      cavia-testing
@@ -242,3 +242,19 @@
       (is (thrown? Exception
                    (vcf-variant->protein-hgvs {:chr "chr7", :pos 55191823, :ref "T", :alt "G"}
                                               test-ref-seq-file rgidx))))))
+
+(deftest coding-dna-ref-gene?-test
+  (testing "valid reference genes"
+    (are [transcript] (#'v2h/coding-dna-ref-gene? {:name transcript})
+      "NM_001005484.2"
+      "NM_001005484"
+      "ENST00000644969.2"
+      "ENST00000644969"))
+  (testing "invalid reference genes"
+    (are [transcript] (not (#'v2h/coding-dna-ref-gene? {:name transcript}))
+      "XM_024451963.1"
+      "XM_024451963"
+      "NR_024540.1"
+      "NR_024540"
+      "ENSP00000496776.1"
+      "ENSP00000496776")))


### PR DESCRIPTION
- [PR 44](https://github.com/chrovis/varity/pull/44) and [PR 43](https://github.com/chrovis/varity/pull/43) implemented loading GENCODE files and looking up by GENCODE ID, but lacks GENCODE ID conversion support
- extracted a function to check if a string is supported transcript ID in hgvs to vcf conversion (`->supported-transcript`)