### PR TITLE
Fix the peformance of liftover-variants.

### DIFF
--- a/test/varity/vcf_lift_test.clj
+++ b/test/varity/vcf_lift_test.clj
@@ -69,7 +69,8 @@
              (ch/load-chain "./test-resources/vcf-lift/sample-rev.chain"))
             (vcf/read-variants vcf-reject-rdr))
            {:failure [{:alt ["A"], :ref "AT", :pos 5, :filter [:PASS], :id nil,
-                       :info {:END 6}, :qual 100.0, :chr "chr1"}]}))))
+                       :info {:END 6}, :qual 100.0, :chr "chr1"}]
+            :success nil}))))
 
 (deftest vcf-forward-lift-test
   (with-open [vcf-forward-rdr


### PR DESCRIPTION
This PR improves the performance of lifting over variants.

In the current `liftover-variants` implementation, sort is called as many times as the number of the mutations, so I changed it so that it is only once.