### PR TITLE
Bump up snapshot version to 0.9.0-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Annotate fusion genes. [#52](https://github.com/chrovis/varity/pull/52)
+
 ### Changed
 
 - Logging liftover failure caused by different refs. [#48](https://github.com/chrovis/varity/pull/48)
 
 ### Fixed
 
-- Fix the peformance of liftover-variants. [#47](https://github.com/chrovis/varity/pull/47)
+- Fix the performance of liftover-variants. [#47](https://github.com/chrovis/varity/pull/47)
 
 ## [0.8.0] - 2021-11-15
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject varity "0.8.1-SNAPSHOT"
+(defproject varity "0.9.0-SNAPSHOT"
   :description "Variant translation library for Clojure"
   :url "https://github.com/chrovis/varity"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
#52 was a large new feature, so I think the snapshot version should be up to `0.9.0-SNAPSHOT`.