### PR TITLE
Update codecov-action to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '16']
+        java: ['8', '11', '17']
         clojure: ['1.8', '1.9', '1.10', '1.11']
     name: Test with Java ${{ matrix.java }} and Clojure ${{ matrix.clojure }}
     steps:
@@ -19,7 +19,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-lein-
     - name: Setup Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
@@ -40,10 +40,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-lein-
     - name: Setup Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
-        java-version: '11'
+        java-version: '17'
     - name: Install dependencies
       run: lein deps
     - name: Generate code coverage
@@ -71,10 +71,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
-        java-version: '11'
+        java-version: '17'
     - name: Deploy
       if: endsWith(needs.get-version.outputs.version, '-SNAPSHOT')
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,8 @@ jobs:
     - name: Install dependencies
       run: lein deps
     - name: Generate code coverage
-      run: |
-        lein cloverage --codecov
-        bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
-    - uses: codecov/codecov-action@v1
+      run: lein cloverage --codecov
+    - uses: codecov/codecov-action@v3
       with:
         files: ./target/coverage/codecov.json
 

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [cljam "0.8.3"]
                  [org.apache.commons/commons-compress "1.21"]
                  [proton "0.2.2"]]
-  :plugins [[lein-cloverage "1.2.1"]
+  :plugins [[lein-cloverage "1.2.4"]
             [lein-codox "0.10.7"]
             [net.totakke/lein-libra "0.1.2"]]
   :test-selectors {:default (complement :slow)


### PR DESCRIPTION
I have updated codecov-action to v3 because v1 (bash uploader) was [deprecated](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1).