### PR TITLE
Change the default :prefer-deletion? to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### BREAKING
+
+The default value of `:prefer-deletion?` option is changed to `false`.
+
+```clojure
+(require '[varity.vcf-to-hgvs :as v2h])
+
+(v2h/vcf-variant->coding-dna-hgvs {:chr "chr7", :pos 140924774, :ref "GGGAGGC", :alt "G"}
+                                  "path/to/hg38.fa" "path/to/refGene.txt.gz")
+;;=> (#clj-hgvs/hgvs "NM_004333:c.-95GCCTCC[3]")
+```
+
+If you hope the previous behavior, specify `:prefer-deletion? true`.
+
+```clojure
+(v2h/vcf-variant->coding-dna-hgvs {:chr "chr7", :pos 140924774, :ref "GGGAGGC", :alt "G"}
+                                  "path/to/hg38.fa" "path/to/refGene.txt.gz"
+                                  {:prefer-deletion? true})
+;;=> (#clj-hgvs/hgvs "NM_004333:c.-77_-72delGCCTCC")
+```
+
 ### Added
 
 - Annotate fusion genes. [#52](https://github.com/chrovis/varity/pull/52)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,13 @@ If you hope the previous behavior, specify `:prefer-deletion? true`.
 ### Changed
 
 - Logging liftover failure caused by different refs. [#48](https://github.com/chrovis/varity/pull/48)
+- Change the default `:prefer-deletion?` to `false`. [#56](https://github.com/chrovis/varity/pull/56)
 
 ### Fixed
 
 - Fix the performance of liftover-variants. [#47](https://github.com/chrovis/varity/pull/47)
+- Fix alt exon calculation for deletion. [#50](https://github.com/chrovis/varity/pull/50)
+- Tweak GENCODE loading performance. [#55](https://github.com/chrovis/varity/pull/55)
 
 ## [0.8.0] - 2021-11-15
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :min-lein-version "2.7.0"
   :dependencies [[org.clojure/clojure "1.11.1" :scope "provided"]
                  [org.clojure/tools.logging "1.2.4"]
-                 [clj-hgvs "0.4.5"]
+                 [clj-hgvs "0.4.6"]
                  [cljam "0.8.3"]
                  [org.apache.commons/commons-compress "1.21"]
                  [proton "0.2.2"]]

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [org.apache.commons/commons-compress "1.21"]
                  [proton "0.2.2"]]
   :plugins [[lein-cloverage "1.2.4"]
-            [lein-codox "0.10.7"]
+            [lein-codox "0.10.8"]
             [net.totakke/lein-libra "0.1.2"]]
   :test-selectors {:default (complement :slow)
                    :slow :slow

--- a/src/varity/vcf_to_hgvs.clj
+++ b/src/varity/vcf_to_hgvs.clj
@@ -67,9 +67,7 @@
       (log/warn "Debug printing throws error" e))))
 
 (def ^:private default-options
-  {;; NOTE: Change default :prefer-deletion to false in the next major release
-   ;;       (0.7.0).
-   :prefer-deletion? true
+  {:prefer-deletion? false
    :prefer-insertion? false
    :tx-margin 5000
    :verbose? false})
@@ -87,9 +85,7 @@
   Options:
 
     :prefer-deletion?  Prefer deletion (e.g. \"c.7_9del\") to repeated
-                       sequences (e.g. \"c.4_6[1]\"), default true for backward
-                       compatibility. The default value plans to be changed to
-                       false in the next major release.
+                       sequences (e.g. \"c.4_6[1]\"), default false.
 
     :prefer-insertion? Prefer insertion (e.g. \"c.9_10insAGG\") to repeated
                        sequences (e.g. \"c.4_6[3]\"), default false.
@@ -159,9 +155,7 @@
   Options:
 
     :prefer-deletion?  Prefer deletion (e.g. \"p.P7_H8del\") to repeated
-                       sequences (e.g. \"p.P5_H6[1]\"), default true for
-                       backward compatibility. The default value plans to be
-                       changed to false in the next major release.
+                       sequences (e.g. \"p.P5_H6[1]\"), default false.
 
     :prefer-insertion? Prefer insertion (e.g. \"c.H9_L10insRPH\") to repeated
                        sequences (e.g. \"c.R4_H6[3]\"), default false.
@@ -231,9 +225,7 @@
   Options:
 
     :prefer-deletion?  Prefer deletion (e.g. \"c.7_9del\") to repeated
-                       sequences (e.g. \"c.4_6[1]\"), default true for backward
-                       compatibility. The default value plans to be changed to
-                       false in the next major release.
+                       sequences (e.g. \"c.4_6[1]\"), default false.
 
     :prefer-insertion? Prefer insertion (e.g. \"c.9_10insAGG\") to repeated
                        sequences (e.g. \"c.4_6[3]\"), default false.


### PR DESCRIPTION
I have changed the default value of `:prefer-deletion?` option to `false`.

```clojure
(require '[varity.vcf-to-hgvs :as v2h])

(v2h/vcf-variant->coding-dna-hgvs {:chr "chr7", :pos 140924774, :ref "GGGAGGC", :alt "G"}
                                  "path/to/hg38.fa" "path/to/refGene.txt.gz")
;;=> (#clj-hgvs/hgvs "NM_004333:c.-95GCCTCC[3]")
```

Though this change was mentioned in #30, I completely forgot to change the default value when releasing 0.7.0.

> Therefore, I plan to change the default :prefer-deletion? to false in the next major release (0.7.0).

The next version is 0.9.0, so I think it is good timing to change the default behavior.

I plan to release 0.9.0 after this PR is merged. Please let me know if there are any ongoing developments.

I confirmed `lein test :all` passed.
