### PR TITLE
Fix frameshift conversion failure

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -175,10 +175,12 @@
                                            :extension
                                            :frame-shift)
               (and (pos? nprefo) (= (first palt-only) \*)) :substitution
-              (not= ref-prot-rest alt-prot-rest) (if (or (and (empty? palt-only)
-                                                              (= (first alt-prot-rest) \*))
-                                                         (= (last palt-only) \*)) :fs-ter-substitution
-                                                     :frame-shift)
+              (not= ref-prot-rest alt-prot-rest) (if (or (and (= (first alt-prot-rest) \*)
+                                                              (>= nprefo npalto)
+                                                              (= palt (subs pref 0 (count palt))))
+                                                         (= (last palt-only) \*))
+                                                   :fs-ter-substitution
+                                                   :frame-shift)
               (or (and (zero? nprefo) (zero? npalto))
                   (and (= nprefo 1) (= npalto 1))) :substitution
               (and prefer-deletion? (pos? nprefo) (zero? npalto)) :deletion

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -205,6 +205,8 @@
         "chr1" 69567 "A" "AT" '("p.L160Sfs*7")
         "chr1" 963222 "GCG" "G" '("p.A386Gfs*12")
         "chr2" 47478341 "T" "TGG" '("p.L762Gfs*2" "p.L696Gfs*2")
+        "chr5" 112839837 "AGTGGCAT" "A" '("p.S1397Ifs*2"
+                                          "p.S1415Ifs*2") ; https://github.com/chrovis/varity/issues/58
 
         ;; frame shift with initiation codon change (e.g. NM_007298:c.-19_80del from BRCA Share)
         "chr17" 43124016 "CCAGATGGGACACTCTAAGATTTTCTGCATAGCATTAATGACATTTTGTACTTCTTCAACGCGAAGAGCAGATAAATCCATTTCTTTCTGTTCCAATGAA" "C"


### PR DESCRIPTION
fixes #58

```clojure
(require '[varity.vcf-to-hgvs :as v2h])

(v2h/vcf-variant->hgvs {:chr "chr5", :pos 112175534, :ref "AGTGGCAT", :alt "A"}
                        "path/to/hg19.fa" "path/to/refGene.txt.gz")
;;=> ({:coding-dna #clj-hgvs/hgvs "NM_001127511:c.4190_4196delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1397Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001127510:c.4244_4250delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1415Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354897:c.4274_4280delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1425Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354896:c.4298_4304delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1433Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354906:c.3395_3401delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1132Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354895:c.4244_4250delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1415Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354905:c.3764_3770delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1255Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354903:c.3941_3947delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1314Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354902:c.3971_3977delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1324Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354901:c.4067_4073delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1356Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354900:c.4121_4127delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1374Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354904:c.3866_3872delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1289Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354899:c.4160_4166delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1387Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001354898:c.4169_4175delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1390Ifs*2"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_000038:c.4244_4250delGTGGCAT",
;;     :protein #clj-hgvs/hgvs "p.S1415Ifs*2"})
```

I confirmed `lein test :all` passed.