### PR TITLE
Feature to filter out refgene index source

### DIFF
--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -63,7 +63,7 @@
   (when s
     (re-find #"^(NM|NR)_.+$" s)))
 
-(defn- load-ncbi-file
+(defn- load-genepred-file
   [f filter-fns]
   (let [filter-fn (apply every-pred filter-fns)]
     (with-open [rdr (io/reader (util/compressor-input-stream f))]
@@ -76,12 +76,12 @@
   {:deprecated "0.8.0"
    :doc "DEPRECATED: Loads f (e.g. refGene.txt(.gz)), returning the all contents as a sequence."}
   [f & {:keys [filter-fns] :or {filter-fns [identity]}}]
-  (load-ncbi-file f filter-fns))
+  (load-genepred-file f filter-fns))
 
 (defn load-ref-seqs
   "Loads f (e.g. ncbiRefSeq.txt(.gz)), returning the all contents as a sequence."
   [f & {:keys [filter-fns] :or {filter-fns [identity]}}]
-  (load-ncbi-file f filter-fns))
+  (load-genepred-file f filter-fns))
 
 (defn- ->gencode-attr
   [attr-str kv-sep]

--- a/src/varity/ref_gene.clj
+++ b/src/varity/ref_gene.clj
@@ -58,24 +58,30 @@
     (update m :cds-end-stat keyword)
     (update m :exon-frames parse-exon-pos)))
 
+(defn rna-accession?
+  [s]
+  (when s
+    (re-find #"^(NM|NR)_.+$" s)))
+
 (defn- load-ncbi-file
-  [f]
-  (with-open [rdr (io/reader (util/compressor-input-stream f))]
-    (->> (line-seq rdr)
-         (map parse-ref-gene-line)
-         (filter #(re-find #"^(NM|NR)_.+$" (:name %)))
-         doall)))
+  [f filter-fns]
+  (let [filter-fn (apply every-pred filter-fns)]
+    (with-open [rdr (io/reader (util/compressor-input-stream f))]
+      (->> (line-seq rdr)
+           (map parse-ref-gene-line)
+           (filter filter-fn)
+           doall))))
 
 (defn load-ref-genes
   {:deprecated "0.8.0"
    :doc "DEPRECATED: Loads f (e.g. refGene.txt(.gz)), returning the all contents as a sequence."}
-  [f]
-  (load-ncbi-file f))
+  [f & {:keys [filter-fns] :or {filter-fns [identity]}}]
+  (load-ncbi-file f filter-fns))
 
 (defn load-ref-seqs
   "Loads f (e.g. ncbiRefSeq.txt(.gz)), returning the all contents as a sequence."
-  [f]
-  (load-ncbi-file f))
+  [f & {:keys [filter-fns] :or {filter-fns [identity]}}]
+  (load-ncbi-file f filter-fns))
 
 (defn- ->gencode-attr
   [attr-str kv-sep]

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -43,6 +43,8 @@
 
       "NM_111.1ENST001.1")))
 
+(defn load-ref-seqs [f] (rg/load-ref-seqs f {:filter-fns [#(rg/rna-accession? (:name %))]}))
+
 (defslowtest hgvs->vcf-variants-test
   (cavia-testing "coding DNA HGVS to vcf variants"
     (let [ref-gene-idx (rg/index (rg/load-ref-genes test-ref-gene-file))]
@@ -82,7 +84,7 @@
         "NM_000059:c.18AG[2]" '({:chr "chr13", :pos 32316477, :ref "AAG", :alt "A"}) ; cf. rs397507623 (+)
         "NM_004333:c.-95_-90[3]" '({:chr "chr7", :pos 140924774, :ref "GGGAGGC", :alt "G"}) ; cf. rs727502907 (-)
         ))
-    (let [ncbi-ref-seq-idx (rg/index (rg/load-ref-seqs test-ncbi-ref-seq-file))]
+    (let [ncbi-ref-seq-idx (rg/index (load-ref-seqs test-ncbi-ref-seq-file))]
       (are [hgvs* e]
           (= (hgvs->vcf-variants (hgvs/parse hgvs*) test-ref-seq-file ncbi-ref-seq-idx) e)
         ;; substitution
@@ -121,7 +123,7 @@
         )))
   (cavia-testing "coding DNA HGVS with gene to vcf variants"
     (let [ref-gene-idx (rg/index (rg/load-ref-genes test-ref-gene-file))
-          ncbi-ref-seq-idx (rg/index (rg/load-ref-seqs test-ncbi-ref-seq-file))]
+          ncbi-ref-seq-idx (rg/index (load-ref-seqs test-ncbi-ref-seq-file))]
       (are [hgvs* gene e]
           (= (hgvs->vcf-variants (hgvs/parse hgvs*) gene test-ref-seq-file ref-gene-idx)
              e)
@@ -221,7 +223,7 @@
                                 {:alt "TCGTGACCGTGAC", :chr "chr7", :pos 140924256, :ref "T"}))))
   (cavia-testing "conversion failure"
     (let [ref-gene-idx (rg/index (rg/load-ref-genes test-ref-gene-file))
-          ncbi-ref-seq-idx (rg/index (rg/load-ref-seqs test-ncbi-ref-seq-file))]
+          ncbi-ref-seq-idx (rg/index (load-ref-seqs test-ncbi-ref-seq-file))]
       (are [hgvs* error-type] (thrown-with-error-type?
                                error-type
                                (hgvs->vcf-variants (hgvs/parse hgvs*)
@@ -246,7 +248,7 @@
           ::h2v/unsupported-hgvs-kind ncbi-ref-seq-idx "NM_004006.2:o.6_8del"))))
   (cavia-testing "protein HGVS with gene to possible vcf variants"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))
-          ncbi-ref-seq-idx (rg/index (rg/load-ref-seqs test-ncbi-ref-seq-file))]
+          ncbi-ref-seq-idx (rg/index (load-ref-seqs test-ncbi-ref-seq-file))]
       (are [hgvs* gene e]
           (= (hgvs->vcf-variants (hgvs/parse hgvs*) gene test-ref-seq-file rgidx)
              (hgvs->vcf-variants (hgvs/parse hgvs*) gene test-ref-seq-file ncbi-ref-seq-idx)
@@ -273,7 +275,7 @@
 (defslowtest protein-hgvs->vcf-variants-with-coding-dna-hgvs-test
   (cavia-testing "protein HGVS with gene to possible vcf variants with coding DNA HGVS"
     (let [ref-gene-idx (rg/index (rg/load-ref-genes test-ref-gene-file))
-          ncbi-ref-seq-idx (rg/index (rg/load-ref-seqs test-ncbi-ref-seq-file))]
+          ncbi-ref-seq-idx (rg/index (load-ref-seqs test-ncbi-ref-seq-file))]
       (are [idx hgvs* gene e]
           (= (protein-hgvs->vcf-variants-with-coding-dna-hgvs (hgvs/parse hgvs*) gene test-ref-seq-file idx)
              e)
@@ -332,7 +334,7 @@
 (defslowtest hgvs->vcf->hgvs-test
   (cavia-testing "protein HGVS with gene to possible vcf variants which gives the same protein HGVS"
     (let [ref-gene-idx (rg/index (rg/load-ref-genes test-ref-gene-file))
-          ncbi-ref-seq-idx (rg/index (rg/load-ref-seqs test-ncbi-ref-seq-file))]
+          ncbi-ref-seq-idx (rg/index (load-ref-seqs test-ncbi-ref-seq-file))]
       (with-open [r (cseq/reader test-ref-seq-file)]
         (are [?idx ?protein-hgvs ?gene-symbol]
             (->> (map :name (rg/ref-genes ?gene-symbol ?idx))

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -70,10 +70,10 @@
            (dissoc test-gtf-row :attribute)))))
 
 (deftest load-ncbi-file-test
-  (testing "refGene.txt and ncbiRefGene.txt produces identical data instead of its accession number"
+  (testing "refGene.txt and ncbiRefGene.txt produces identical data other than accession number"
     (is (apply = (map #(-> % first (dissoc :name))
-                      [(#'rg/load-ncbi-file test-load-refgene-file)
-                       (#'rg/load-ncbi-file test-load-refseq-file)])))))
+                      [(#'rg/load-ncbi-file test-load-refgene-file [identity])
+                       (#'rg/load-ncbi-file test-load-refseq-file [identity])])))))
 
 (def parsed-gtf-region (first (rg/load-gtf test-gtf-file)))
 
@@ -463,7 +463,8 @@
 (defslowtest cds-coord-slow-test
   (cavia-testing "cds-coord (slow)"
     (let [ref-gene-idx (rg/index (rg/load-ref-genes test-ref-gene-file))
-          ncbi-ref-seq-idx (rg/index (rg/load-ref-seqs test-ncbi-ref-seq-file))]
+          ncbi-ref-seq-idx (rg/index (rg/load-ref-seqs test-ncbi-ref-seq-file
+                                                       {:filter-fns [#(rg/rna-accession? (:name %))]}))]
       (are [idx c p r] (= (cds-coord c p idx) r)
         ref-gene-idx "chr7"  55191822  '("2573")
         ref-gene-idx "chr19" 1220596   '("613")

--- a/test/varity/ref_gene_test.clj
+++ b/test/varity/ref_gene_test.clj
@@ -72,8 +72,8 @@
 (deftest load-ncbi-file-test
   (testing "refGene.txt and ncbiRefGene.txt produces identical data other than accession number"
     (is (apply = (map #(-> % first (dissoc :name))
-                      [(#'rg/load-ncbi-file test-load-refgene-file [identity])
-                       (#'rg/load-ncbi-file test-load-refseq-file [identity])])))))
+                      [(#'rg/load-genepred-file test-load-refgene-file [identity])
+                       (#'rg/load-genepred-file test-load-refseq-file [identity])])))))
 
 (def parsed-gtf-region (first (rg/load-gtf test-gtf-file)))
 


### PR DESCRIPTION
## Problem
- refGene.txt contains contig's records like `chr6_cox_hap2` but we sometimes don't need contig's records at all.
- There is no way to ignore arbitrary rows in refGene.txt (and ncbiRefSeq.txt).

## Implementation
- I add an optional arg `filter-fns` to `load-ref-genes` and `load-ref-seqs` to filter out unnecessary rows in these files.
- I also renamed function `load-ncbi-file` to `load-genepred-file` because these files format are named as [GenePred](https://genome.ucsc.edu/FAQ/FAQformat.html#format9) (just refactoring).