### PR TITLE
fix conditional branch of frameshift caused by insertion

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -178,7 +178,7 @@
               (not= ref-prot-rest alt-prot-rest) (if (or (and (= (first alt-prot-rest) \*)
                                                               (>= nprefo npalto)
                                                               (= palt (subs pref 0 (count palt))))
-                                                         (= (last palt-only) \*))
+                                                         (= (first palt-only) \*))
                                                    :fs-ter-substitution
                                                    :frame-shift)
               (or (and (zero? nprefo) (zero? npalto))

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -182,6 +182,7 @@
         "chr2" 47478341 "TG" "T" '("p.L762*" "p.L696*") ;; rs786204050 (+) frameshift with termination
         "chr8" 42838217 "GAGATTAACAGGGGTCTGAAGAGGCGGCATTAGTAATCCAATAGCAGCATCAACCTGGGAAACAGGAGGCGGTAAAGGAGGTGGGGGAAGCTGTTCCTGTGGCTCCAGAAGATCTTCTTTCTAAAACAAAAATACAAAGTATGTTTGAATTTAGTAACTAAAAACAGTTTAAA" "G"
         '("p.K90Lfs*5" "p.K25*") ; cf. VCV000965170.1 (-, frameshift with termination)
+        "chr17" 7676202 "T" "TGTCCCTTAGTCTT" '("p.P58*" "p.P19*") ; cf. not actual example (-, frameshift with termination)
 
         ;; deletion
         "chr1" 240092288 "AGTC" "A" '("p.S61del") ; cf. rs772088733 (+)


### PR DESCRIPTION
I have fixed :fs-ter-substitution conditional branch.

:fs-ter-substitution should be returned when `first` amino acid of palt-only is stop codon.