### PR TITLE
Fix the position of first amino acid changed by the frame shift

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -278,16 +278,14 @@
                                alt-repeat)))
 
 (defn- protein-frame-shift
-  [ppos pref palt seq-info]
-  (let [[ppos pref palt] (if (= pref palt)
-                           (->> (map vector (:ref-prot-seq seq-info) (:alt-prot-seq seq-info))
-                                (drop (dec ppos))
-                                (map-indexed vector)
-                                (drop-while (fn [[_ [r a]]] (= r a)))
-                                first
-                                ((fn [[i [r a]]]
-                                   [(+ ppos i) (str r) (str a)])))
-                           [ppos pref palt])
+  [ppos seq-info]
+  (let [[ppos pref palt] (->> (map vector (:ref-prot-seq seq-info) (:alt-prot-seq seq-info))
+                              (drop (dec ppos))
+                              (map-indexed vector)
+                              (drop-while (fn [[_ [r a]]] (= r a)))
+                              first
+                              ((fn [[i [r a]]]
+                                 [(+ ppos i) (str r) (str a)])))
         [_ _ offset _] (diff-bases pref palt)
         alt-prot-seq (format-alt-prot-seq seq-info)
         ref (nth (:ref-prot-seq seq-info) (dec (+ ppos offset)))
@@ -338,7 +336,7 @@
           :insertion (protein-insertion ppos pref palt seq-info)
           :indel (protein-indel ppos pref palt)
           :repeated-seqs (protein-repeated-seqs ppos pref palt seq-info)
-          :frame-shift (protein-frame-shift ppos pref palt seq-info)
+          :frame-shift (protein-frame-shift ppos seq-info)
           :extension (protein-extension ppos pref palt seq-info)
           :no-effect (mut/protein-no-effect)
           :unknown (mut/protein-unknown-mutation))))))

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -214,6 +214,7 @@
         "chr2" 47478341 "T" "TGG" '("p.L762Gfs*2" "p.L696Gfs*2")
         "chr5" 112839837 "AGTGGCAT" "A" '("p.S1397Ifs*2"
                                           "p.S1415Ifs*2") ; https://github.com/chrovis/varity/issues/58
+        "chr17" 31261816 "CC" "C" '("p.N1542Tfs*11" "p.N1563Tfs*11") ; cf. rs1555619041 (+)
 
         ;; frame shift with initiation codon change (e.g. NM_007298:c.-19_80del from BRCA Share)
         "chr17" 43124016 "CCAGATGGGACACTCTAAGATTTTCTGCATAGCATTAATGACATTTTGTACTTCTTCAACGCGAAGAGCAGATAAATCCATTTCTTTCTGTTCCAATGAA" "C"


### PR DESCRIPTION
I have fixed the position of first amino acid changed by the frame shift.

```clojure
(require '[varity.vcf-to-hgvs :as v2h])

(v2h/vcf-variant->hgvs
 {:chr "chr17", :pos 31261816, :ref "CC", :alt "C"}
 "path/to/hg38.fa" "path/to/refGene.txt.gz" {:prefer-deletion? true})
```

- before fix
```clojure
;;=> ({:coding-dna #clj-hgvs/hgvs "NM_000267:c.4621delC",
;;     :protein #clj-hgvs/hgvs "p.L1541=fs*12"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001042492:c.4684delC",
;;     :protein #clj-hgvs/hgvs "p.L1562=fs*12"})
```

- after fix
```clojure
;;=> ({:coding-dna #clj-hgvs/hgvs "NM_000267:c.4621delC",
;;     :protein #clj-hgvs/hgvs "p.N1542Tfs*11"}
;;    {:coding-dna #clj-hgvs/hgvs "NM_001042492:c.4684delC",
;;     :protein #clj-hgvs/hgvs "p.N1563Tfs*11"})
```