### PR TITLE
Fix VCF to protein HGVS conversions of insertions near splice sites

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -24,6 +24,14 @@
               :else :same)
         tpos (+ pos (min nref nalt))
         d (Math/abs (- nref nalt))]
+    (when (and (not= 1 nref) (not= 1 nalt)
+               (some (fn [[s e]]
+                       (or (<= pos s (+ pos nref -1))
+                           (<= pos e (+ pos nref -1)))) exon-ranges))
+      (throw
+       (ex-info
+        "Variants overlapping a boundary of exon/intron are unsupported"
+        {:exon-ranges exon-ranges, :pos pos, :ref ref, :alt alt})))
     (->> exon-ranges
          (keep (fn [[s e]]
                  (case typ

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -81,7 +81,9 @@
         ref-down-exon-seq1 (read-exon-sequence seq-rdr chr (inc cds-end) tx-end exon-ranges)
         nref-down-exon-seq1 (count ref-down-exon-seq1)
         ref-down-exon-seq1 (subs ref-down-exon-seq1 0 (- nref-down-exon-seq1 (mod nref-down-exon-seq1 3)))
-        alt-exon-seq1 (exon-sequence alt-seq cds-start alt-exon-ranges*)]
+        alt-exon-seq1 (exon-sequence alt-seq cds-start alt-exon-ranges*)
+        apply-offset #(or (ffirst (alt-exon-ranges [[% %]] pos ref alt))
+                          (some (fn [[_ e]] (when (<= e %) e)) alt-exon-ranges*))]
     {:ref-exon-seq ref-exon-seq1
      :ref-prot-seq (codon/amino-acid-sequence (cond-> ref-exon-seq1
                                                 (= strand :reverse) util-seq/revcomp))
@@ -94,7 +96,11 @@
      :ini-offset (quot (:position (rg/cds-coord (case strand
                                                   :forward tx-start
                                                   :reverse tx-end) rg))
-                       3)}))
+                       3)
+     :alt-rg (-> rg
+                 (assoc :exon-ranges alt-exon-ranges*)
+                 (update :cds-start apply-offset)
+                 (update :cds-end apply-offset))}))
 
 (defn- protein-position
   "Converts genomic position to protein position. If pos is outside of CDS,
@@ -132,7 +138,7 @@
 
 (defn- ->protein-variant
   [{:keys [strand] :as rg} pos ref alt
-   {:keys [ref-exon-seq ref-prot-seq alt-exon-seq] :as seq-info}
+   {:keys [ref-exon-seq ref-prot-seq alt-exon-seq alt-rg] :as seq-info}
    {:keys [prefer-deletion? prefer-insertion?]}]
   (cond
     (= ref-exon-seq alt-exon-seq)
@@ -159,8 +165,8 @@
                                   alt-prot-seq*
                                   [(min (dec base-ppos) (count alt-prot-seq*))
                                    (min (case strand
-                                          :forward (protein-position (+ pos (count alt) -1) rg)
-                                          :reverse (protein-position (- pos (- (count alt) (count ref))) rg))
+                                          :forward (protein-position (+ pos (count alt) -1) alt-rg)
+                                          :reverse (protein-position pos alt-rg))
                                         (count alt-prot-seq*))])
           [pref-only palt-only offset _] (diff-bases pref palt)
           nprefo (count pref-only)

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -6,7 +6,6 @@
 (deftest alt-exon-ranges-test
   ;; 1 [2 3 4] 5 6 7 [8 9 10 11] 12 13 14 15
   (are [p r a e] (= (#'prot/alt-exon-ranges [[2 4] [8 11]] p r a) e)
-    3 "XXX" "XXX" [[2 4] [8 11]]
     3 "X" "XXX" [[2 6] [10 13]]
     6 "X" "XXX" [[2 4] [10 13]]
     2 "XX" "X" [[2 3] [7 10]]
@@ -14,7 +13,12 @@
     6 "XX" "X" [[2 4] [7 10]]
     6 "XXX" "X" [[2 4] [7 9]]
     3 "XXX" "X" [[2 3] [6 9]]
-    1 "XXXXX" "X" [[4 7]]))
+    1 "XXXXX" "X" [[4 7]])
+  ;; Can't determine whether the splice site is shifted or not
+  (is (thrown-with-msg?
+       Exception
+       #"unsupported"
+       (#'prot/alt-exon-ranges [[2 4] [8 11]] 3 "XXX" "XXX"))))
 
 (deftest exon-sequence-test
   ;; A  C G T  A C G  T A C  G   T  A  C  G

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -248,7 +248,10 @@
 
         ;; prefer-insertion?, cf. rs3046924 (+)
         "chr1" 47438996 "T" "TCCGCAC" {:prefer-insertion? false} '("p.P286_H287[5]")
-        "chr1" 47438996 "T" "TCCGCAC" {:prefer-insertion? true} '("p.H293_A294insPH"))))
+        "chr1" 47438996 "T" "TCCGCAC" {:prefer-insertion? true} '("p.H293_A294insPH")
+
+        ;; prefer-insertion?, not actual example (+)
+        "chr1" 26773690 "C" "CGCAGCA" {:prefer-insertion? true} '("p.Q1334_R1335insQQ"))))
 
   (cavia-testing "throws Exception if inputs are illegal"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]


### PR DESCRIPTION
##### Summary
This PR fixes a problem in `varity.vcf-to-hgvs/vcf-variant->protein-hgvs` reported by #67.

##### Problem
The test case of #67 fails on master branch returning an incorrect value, `p.R1335Qfs*954`
```clojure
{:chr "chr1", :pos 26773690, :ref "C", :alt "CGCAGCA"}
```

As ARID1A is on the `:forward` strand and there's a repeated sequence of `GCA` around the variant, 3'-rule realigns the variant to the following one:
```clojure
{:chr "chr1", :pos 26773714, :ref "A", :alt "AGCAGCA"}
```

This can be illustrated as follows. The correct output should be `p.Q1334_R1335insQQ`.
```hs
pos  26773...                          ↓POS              ↓POS+6
     666 666 666 667 777 777 777 777 7 7         7 77            8 888 888
     899 999 999 990 000 000 000 111 1 1         1 11            0 000 000
     901 234 567 890 123 456 789 012 3 4         5 67            2 345 678
pref ┌P┐ ┌Q┐ ┌Q┐ ┌Q┐ ┌Q┐ ┌Q┐ ┌Q┐ ┌Q┐ ┌─────Q─────┐ ┌R─  intron  ─┐ ┌H┐ ┌D┐
REF  CCG_CAG_CAG_CAG_CAG_CAG_CAG_CAG_C[A        ]A_CG  gt....ag  A_CAT_GAT
ALT  CCG_CAG_CAG_CAG_CAG_CAG_CAG_CAG_C[AG_CAG_CA]A_CG  gt....ag  A_CAT_GAT
palt └P┘ └Q┘ └Q┘ └Q┘ └Q┘ └Q┘ └Q┘ └Q┘ └Q─┘ └Q┘ └Q─┘ └R─          ─┘ └H┘ └D┘
```

##### Cause
`varity.vcf-to-hgvs.protein/->protein-variant` splits REF and ALT AA sequences into three parts each:
1. common prefix
2. directly affected subsequence
3. the remaining which may have a frame shift

https://github.com/chrovis/varity/blob/e401a36a86edb23b2555c07580b463d1fb453b1a/src/varity/vcf_to_hgvs/protein.clj#L152-L164

At L162, a genomic position `(+ pos (count alt) -1)` is converted into a transcript coordinate by `varity.vcf-to-hgvs.protein/protein-position` to calculate the end index of the direct effect (2.) in the ALT AA sequence.
But the position `(+ pos (count alt) -1)`, which evaluates to be `26774720`, is inside of an intron and thus be clamped to the start position of the subsequent exon: `26773802`
https://github.com/chrovis/varity/blob/e401a36a86edb23b2555c07580b463d1fb453b1a/src/varity/vcf_to_hgvs/protein.clj#L105-L110
resulting in an incorrect splitting and an incorrect HGVS `p.R1335Qfs*954`
```
REF: ...QQQ QR HD...
ALT: ...QQQ QQ QRHD...
```

##### Fix
This PR fixes the coordinate converting by shifting feature positions in refGene entry by applying ALT.
https://github.com/chrovis/varity/blob/1edd963d6bd8b9570950dcdcd27f6df3fcf75c79/src/varity/vcf_to_hgvs/protein.clj#L100-L103
Along with `:exon-ranges` which is already calculated as `alt-exon-ranges*`, `:cds-(start|end)` are converted using the same fn: `varity.vcf-to-hgvs.protein/alt-exon-ranges`. 
With these changes applied, `(+ pos (count alt) -1)` will no longer come in an intron, allowing the correct conversion of positions.
```
REF: ...QQQ Q   RHD...
ALT: ...QQQ QQQ RHD...
```

##### Known issues
Since the current implementation relies only on positions, it will fail if a realigned variant contains a boundary of exon and intron.

https://github.com/chrovis/varity/blob/6f322e0a2c6425b8ae114227cfa4607f27773aad/test/varity/vcf_to_hgvs_test.clj#L275-L286

This PR does not address the issue. When such a situation is detected, it just throws an exception instead of returning an incorrect result. 6f322e0a2c6425b8ae114227cfa4607f27773aad