### PR TITLE
fix overlapping condition of boundary of exon/intron 

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -26,8 +26,10 @@
         d (Math/abs (- nref nalt))]
     (when (and (not= 1 nref) (not= 1 nalt)
                (some (fn [[s e]]
-                       (or (<= pos s (+ pos nref -1))
-                           (<= pos e (+ pos nref -1)))) exon-ranges))
+                       (and (not= s e)
+                            (or (and (< pos s) (<= s (+ pos nref -1)))
+                                (and (<= pos e) (< e (+ pos nref -1))))))
+                     exon-ranges))
       (throw
        (ex-info
         "Variants overlapping a boundary of exon/intron are unsupported"
@@ -91,7 +93,7 @@
         ref-down-exon-seq1 (subs ref-down-exon-seq1 0 (- nref-down-exon-seq1 (mod nref-down-exon-seq1 3)))
         alt-exon-seq1 (exon-sequence alt-seq cds-start alt-exon-ranges*)
         apply-offset #(or (ffirst (alt-exon-ranges [[% %]] pos ref alt))
-                          (some (fn [[_ e]] (when (<= e %) e)) (reverse alt-exon-ranges*)))]
+                          (some (fn [[_ e]] (if (<= e %) e)) (reverse alt-exon-ranges*)))]
     {:ref-exon-seq ref-exon-seq1
      :ref-prot-seq (codon/amino-acid-sequence (cond-> ref-exon-seq1
                                                 (= strand :reverse) util-seq/revcomp))

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -68,7 +68,7 @@
 
 (deftest prot-seq-pstring-test
   (are [pref-seq palt-seq start end m e]
-      (= (#'prot/prot-seq-pstring pref-seq palt-seq start end m) e)
+       (= (#'prot/prot-seq-pstring pref-seq palt-seq start end m) e)
     "LAARNVLVKTPQHVKITDFGLAKLLGAEEKEYHAEGGKVPI"
     "LAARNVLVKTPQHVKITDFGRAKLLGAEEKEYHAEGGKVPI"
     838 878 {:ppos 858, :pref "L", :palt "R"}
@@ -117,6 +117,6 @@
               :exon-frames [2 0 1 2 0 1 0 0 2 0 -1]
               :exon-count 11}]
     (are [pos ref alt res]
-        (= (with-open [seq-rdr (cseq/reader test-ref-seq-file)] (#'prot/mutation seq-rdr tp53 pos ref alt {})) res)
+         (= (with-open [seq-rdr (cseq/reader test-ref-seq-file)] (#'prot/mutation seq-rdr tp53 pos ref alt {})) res)
       7676197 "G" "GGTCTTGTCCCTTA" (:mutation (hgvs/parse "p.P58*"))
       7676202 "T" "TGTCCCTTAGTCTT" (:mutation (hgvs/parse "p.P58*")))))

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -17,7 +17,8 @@
     6 "XX" "X" [[2 4] [7 10]]
     6 "XXX" "X" [[2 4] [7 9]]
     3 "XXX" "X" [[2 3] [6 9]]
-    1 "XXXXX" "X" [[4 7]])
+    1 "XXXXX" "X" [[4 7]]
+    9 "XXX" "XXX" [[2 4] [8 11]])
   ;; Can't determine whether the splice site is shifted or not
   (is (thrown-with-msg?
        Exception

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -239,6 +239,7 @@
         ;; Extension
         "chr2" 188974490 "A" "C" '("p.M1Lext-23")
         "chr2" 189011772 "T" "C" '("p.*1467Qext*45") ; cf. ClinVar 101338
+        "chr11" 125655318 "TGA" "TAT" '("p.*477Yext*17" "p.*443Yext*17" "p.*477Yext*24")
         ;; NOTE: There are very few correct examples...
 
         ;; no effect


### PR DESCRIPTION
I found `Variants overlapping a boundary of exon/intron are unsupported error` when mutation occur at termination codon.
Then I fix boundary of exon/intron overlapping condition.