### PR TITLE
Fix upstream and downstream sequence of sequence-info and delins process

### DIFF
--- a/src/varity/vcf_to_hgvs/common.clj
+++ b/src/varity/vcf_to_hgvs/common.clj
@@ -13,15 +13,18 @@
 (defn diff-bases
   "Compares VCF-style base(s) s1 and s2, returning a vector of
   [bases-only-in-s1 bases-only-in-s2 left-common-len right-common-len]."
-  [s1 s2]
-  (let [l (left-common-len s1 s2)
-        ls1 (subs s1 l)
-        ls2 (subs s2 l)
-        r (left-common-len (reverse ls1) (reverse ls2))]
-    [(subs ls1 0 (- (count ls1) r))
-     (subs ls2 0 (- (count ls2) r))
-     l
-     r]))
+  ([s1 s2] (diff-bases s1 s2 0))
+  ([s1 s2 offset]
+   (let [s1 (subs s1 offset)
+         s2 (subs s2 offset)
+         l (left-common-len s1 s2)
+         ls1 (subs s1 l)
+         ls2 (subs s2 l)
+         r (left-common-len (reverse ls1) (reverse ls2))]
+     [(subs ls1 0 (- (count ls1) r))
+      (subs ls2 0 (- (count ls2) r))
+      l
+      r])))
 
 (def max-repeat-unit-size 100)
 

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -438,7 +438,9 @@
         ter-site (some-> (string/index-of rest-seq (if (= ppos 1) "M" "*")) inc)]
     (mut/protein-extension (if (= ppos 1) "Met" "Ter")
                            (coord/protein-coordinate (if (= ppos 1) 1 (+ ppos offset)))
-                           (mut/->long-amino-acid (last ins))
+                           (mut/->long-amino-acid (if (= ppos 1)
+                                                    (last ins)
+                                                    (or (last ins) (first rest-seq))))
                            (if (= ppos 1) :upstream :downstream)
                            (if ter-site
                              (coord/protein-coordinate ter-site)

--- a/test/varity/vcf_to_hgvs/common_test.clj
+++ b/test/varity/vcf_to_hgvs/common_test.clj
@@ -15,7 +15,13 @@
       "CAG" "CTC"     ["AG" "TC" 1 0]
       "CA"  "CTC"     ["A"  "TC" 1 0]
       "CAG" "CT"      ["AG" "T" 1 0]
-      "CAGTC" "CTGAC" ["AGT" "TGA" 1 1])))
+      "CAGTC" "CTGAC" ["AGT" "TGA" 1 1]))
+  (testing "diff-bases with offset"
+    (are [s1 s2 offset ret] (= (common/diff-bases s1 s2 offset) ret)
+      "CGATC"    "CGTTG"     3 ["C" "G" 1 0]
+      "C"        "CA"        1 ["" "A" 0 0]
+      "TCG"      "TCAG"      2 ["" "A" 0 1]
+      "GATCTGAA" "GATCGATCA" 3 ["TGA" "GATC" 1 1])))
 
 (deftest repeat-units-test
   (are [s ret] (= (#'common/repeat-units s) ret)

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -31,6 +31,58 @@
   ;; 1 [2 3 4] 5 6 7 [8 9 10 11] 12 13 14 15
   (is (= (#'prot/exon-sequence "ACGTACGTACGTACG" 1 [[2 4] [8 11]]) "CGTTACG")))
 
+(deftest make-alt-up-exon-seq-test
+  (let [ref-up-exon-seq "AATGCTTCTAGCTCC"
+        cds-start 100]
+    (are [p pos ref alt] (= p (#'prot/make-alt-up-exon-seq ref-up-exon-seq
+                                                           cds-start
+                                                           pos
+                                                           ref
+                                                           alt))
+      "AATGCTTCTAGCTCC" 102 "ATGTC" "A"
+      "ATGCTTCTAGCT" 98 "CCTT" "C")))
+
+(deftest make-alt-down-exon-seq-test
+  (let [ref-up-exon-seq "CTTATAATAATAA"
+        cds-end 1000]
+    (are [p pos ref alt] (= p (#'prot/make-alt-down-exon-seq ref-up-exon-seq
+                                                             cds-end
+                                                             pos
+                                                             ref
+                                                             alt))
+      "CTTATAATAATA" 1002 "TTATAA" "T"
+      "TATAATAAT" 998 "GGCCT" "G")))
+
+(deftest make-ter-site-adjusted-alt-seq-test
+  (let [alt-seq "XXXXXX"
+        upstream-seq "YYYYYY"
+        downstream-seq "ZZZZZZ"
+        [cds-start cds-end] [7 12]]
+    (are [p strand pos ref] (#'prot/make-ter-site-adjusted-alt-seq alt-seq
+                                                                   upstream-seq
+                                                                   downstream-seq
+                                                                   strand
+                                                                   cds-start
+                                                                   cds-end
+                                                                   pos
+                                                                   ref)
+      "XXXXXX" :forward 8 "XX"
+      "XXXXXX" :forward 5 "YY"
+      "XXXXXX" :forward 5 "YYX"
+      "XXXXXX" :forward 13 "ZZ"
+      "XXXXXXZZZZZZ" :forward 12 "XZZ"
+      "XXXXXX" :reverse 8 "XX"
+      "XXXXXX" :reverse 5 "YY"
+      "YYYYYYXXXXXX" :reverse 5 "YYX"
+      "XXXXXX" :reverse 13 "ZZ"
+      "XXXXXX" :reverse 12 "XZZ")))
+
+(deftest get-pos-exon-end-tuple-test
+  (let [exon-ranges [[1 10] [15 20] [25 40]]]
+    (are [p pos] (= (#'prot/get-pos-exon-end-tuple pos exon-ranges) p)
+      [15 20] 15
+      [5 10] 5)))
+
 (def ref-gene-EGFR
   {:bin 125
    :name "NM_005228"

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -83,6 +83,15 @@
       [15 20] 15
       [5 10] 5)))
 
+(deftest get-first-diff-aa-info-test
+  (let [ref-seq "ABCDEFGHIJKLMN"]
+    (are [p alt-seq pos] (= (#'prot/get-first-diff-aa-info pos
+                                                           ref-seq
+                                                           alt-seq)
+                            p)
+      {:ppos 6 :pref "F" :palt "G"} "ABCDEG" 4
+      {:ppos 13 :pref "M" :palt "K"} "ACBDEFGHIJKLK" 10)))
+
 (def ref-gene-EGFR
   {:bin 125
    :name "NM_005228"

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -114,8 +114,7 @@
         ref "GCTGACC"
         alt "G"
         exon-ranges [[10 50] [80 120] [150 200]]]
-    (are [pos* ref-include-ter-site p] (= ((#'prot/apply-offset pos ref alt exon-ranges ref-include-ter-site) pos*)
-                                          p)
+    (are [pos* ref-include-ter-site p] (= (#'prot/apply-offset pos ref alt exon-ranges ref-include-ter-site pos*) p)
       40 false 40
       110 false 104
       105 true 101

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -218,6 +218,9 @@
         "chr2" 47445589 "CTTACTGAT" "CCC" '("p.L440_D442delinsP" "p.L374_D376delinsP") ; cf. rs63749931 (+)
         "chr1" 152111364 "TGC" "TCG" '("p.E617_Q618delinsDE") ; cf. rs35444647 (-)
 
+        ;; indel include stop codon deletion
+        "chr8" 116847497 "TCCTTATATAATATGGAACCTTGGTCCAGGTGTTGCGATGATGTCACTGTA" "T" '("p.Y617_I631delinsS")
+
         ;; repeated sequences
         "chr1" 47438996 "T" "TCCGCAC" '("p.P286_H287[5]") ; cf. rs3046924 (+)
         "chr1" 11796319 "C" "CGGCGGC" '("p.A222[3]") ; not actual example (-)
@@ -230,11 +233,19 @@
                                           "p.S1415Ifs*2") ; https://github.com/chrovis/varity/issues/58
         "chr17" 31261816 "CC" "C" '("p.N1542Tfs*11" "p.N1563Tfs*11") ; cf. rs1555619041 (+)
 
+        ;; Frame shift without termination site
+        "chr17" 81537070 "G" "GTA" '("p.W514Cfs*?" "p.W490Cfs*?") ; not actual example (+)
+        "chr17" 9771493 "CCT" "C" '("p.E310Gfs*?" "p.E311Gfs*?") ; not actual example (-)
+
         ;; Extension
         "chr2" 188974490 "A" "C" '("p.M1Lext-23")
         "chr2" 189011772 "T" "C" '("p.*1467Qext*45") ; cf. ClinVar 101338
         "chr11" 125655318 "TGA" "TAT" '("p.*477Yext*17" "p.*443Yext*17" "p.*477Yext*24")
         ;; NOTE: There are very few correct examples...
+
+        ;; Extension without termination site
+        "chr17" 81537077 "CT" "C" '("p.*517ext*?" "p.*493ext*?") ; not actual example (+)
+        "chr17" 9771487 "GT" "G" '("p.*312Yext*?" "p.*313Yext*?") ; not actual example (-)
 
         ;; no effect
         "chr7" 55181876 "A" "T" '("p.=") ; not actual example (+)
@@ -243,6 +254,10 @@
 
         ;; unknown
         "chr12" 40393453 "G" "A" '("p.?") ; not actual example (+)
+
+        ;; unknown because variant includes termination site and alternative termination site is not found
+        "chr17" 81537074 "GTACTGAGGC" "G" '("p.?") ; not actual example(+)
+        "chr17" 9771484 "GCAGTTACC" "G" '("p.?") ; not actual example(-)
         )))
 
   (cavia-testing "options"

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -244,7 +244,7 @@
         ;; NOTE: There are very few correct examples...
 
         ;; Extension without termination site
-        "chr17" 81537077 "CT" "C" '("p.*517ext*?" "p.*493ext*?") ; not actual example (+)
+        "chr17" 81537077 "CT" "C" '("p.*517Eext*?" "p.*493Eext*?") ; not actual example (+)
         "chr17" 9771487 "GT" "G" '("p.*312Yext*?" "p.*313Yext*?") ; not actual example (-)
 
         ;; no effect


### PR DESCRIPTION
I fixed the sequence-info and delins because error occurred when gene is transcribed from reverse strand and variant includes stop codon and upstream sequence from cds.

I found upstream and downstream sequence is not corrected when deletion is extended to outside of cds.
So I fix upstream sequence from cds-start and downstream sequence from cds-end, protein alteration type determinning process and delins process.

I executed `lein run` and `lein run :slow` and I confirmed all tests are passed.