### PR TITLE
Return protein-hgvs nil when variant overlaps exon/intron boundaries

### DIFF
--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -17,10 +17,7 @@
     6 "XX" "X" [[2 4] [7 10]]
     9 "XXX" "XXX" [[2 4] [8 11]])
   ;; Variants overlapping a boundary of exon/intron
-  (are [p r a] (thrown-with-msg?
-                Exception
-                #"unsupported"
-                (#'prot/alt-exon-ranges [[2 4] [8 11]] p r a))
+  (are [p r a] (nil? (#'prot/alt-exon-ranges [[2 4] [8 11]] p r a))
     3 "XXX" "XXX"
     6 "XXX" "X"
     3 "XXX" "X"

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -286,15 +286,11 @@
                    (vcf-variant->protein-hgvs {:chr "chr7", :pos 55191823, :ref "T", :alt "G"}
                                               test-ref-seq-file rgidx)))))
 
-  (cavia-testing "throws Exception if inputs overlap exon/intron boundaries"
+  (cavia-testing "case that inputs overlap exon/intron boundaries"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [chr pos ref alt]
-           (thrown-with-msg?
-            Exception
-            #"unsupported"
-            (vcf-variant->protein-hgvs
-             {:chr chr, :pos pos, :ref ref, :alt alt}
-             test-ref-seq-file rgidx))
+           (= [] (vcf-variant->protein-hgvs {:chr chr, :pos pos, :ref ref, :alt alt}
+                                            test-ref-seq-file rgidx))
         ;; Two variants at the each side of a GT dinucleotide splice donor site
         "chr1" 26773716 "CGGTGA" "CCAGGTGT"
         "chr1" 26773714 "AACGGTGAG" "AGCGGT"


### PR DESCRIPTION
When variant overlaps exon/intron boundaries, throw exception now.
In this PR, I fix to return nil because it difficult to get coding-dan-alteration when it failed to get protein-alteration.