### PR TITLE
Refactor and generalize overlap-exon-intron-boundary?

### DIFF
--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -7,6 +7,17 @@
             [varity.t-common :refer [test-ref-seq-file
                                      defslowtest]]))
 
+(deftest overlap-exon-intron-boundary?-test
+  (let [exon-ranges [[123 321] [456 654] [789 987]]]
+    (are [p pos ref alt] (p (#'prot/overlap-exon-intron-boundary? exon-ranges pos ref alt))
+      false? 454 "X" "Y"
+      true? 454 "XXX" "X"
+      false? 455 "XX" "X"
+      false? 456 "XX" "X"
+      false? 654 "XX" "X"
+      true? 653 "XXX" "X"
+      false? 653 "XX" "X")))
+
 (deftest alt-exon-ranges-test
   ;; 1 [2 3 4] 5 6 7 [8 9 10 11] 12 13 14 15
   (are [p r a e] (= (#'prot/alt-exon-ranges [[2 4] [8 11]] p r a) e)
@@ -15,10 +26,10 @@
     2 "XX" "X" [[2 3] [7 10]]
     3 "XX" "X" [[2 3] [7 10]]
     6 "XX" "X" [[2 4] [7 10]]
-    9 "XXX" "XXX" [[2 4] [8 11]])
+    9 "XXX" "YYY" [[2 4] [8 11]])
   ;; Variants overlapping a boundary of exon/intron
   (are [p r a] (nil? (#'prot/alt-exon-ranges [[2 4] [8 11]] p r a))
-    3 "XXX" "XXX"
+    3 "XXX" "YYY"
     6 "XXX" "X"
     3 "XXX" "X"
     1 "XXXXX" "X"))


### PR DESCRIPTION
I have made some updates to the #92. Specifically, I have refactored and generalized the 'overlap-exon-intron-boundary?' function using `diff-bases` and added tests.