### PR TITLE
Add no-effect branch to protein type determine process

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -318,7 +318,9 @@
                                                      pref-only
                                                      palt-only)
           t (cond
-              (= (+ base-ppos offset) (count ref-prot-seq)) :extension
+              (= (+ base-ppos offset) (count ref-prot-seq)) (if (= "" pref-only palt-only)
+                                                              :no-effect
+                                                              :extension)
               (= (+ base-ppos offset) 1) (if (= ref-prot-rest alt-prot-rest)
                                            :extension
                                            :frame-shift)

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -256,6 +256,7 @@
         "chr7" 55181876 "A" "AGGT" '("p.=") ; not actual example (+)
         "chr3" 149520808 "C" "CTTAA" '("p.=") ; not actual example (-)
         "chr17" 80090386 "CAGCACGTGCATGAACAACACAGGACACACACAGCACGTGCATGAACAACACAGGACACACACA" "C" '("p.=") ; not actural example (+)
+        "chr11" 14279340 "G" "A" '("p.=") ; not actual example (-)
 
         ;; unknown
         "chr12" 40393453 "G" "A" '("p.?") ; not actual example (+)


### PR DESCRIPTION
I found no-effect protein sequence is determined as extension when protein variant position is second last codon and pref and palt are equivalent.
So I added no-effect branch.