### PR TITLE
Add extension conditional branch and fix protein-extension

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -268,12 +268,19 @@
 
 (defn- get-first-diff-aa-info
   [pos ref-seq alt-seq]
-  (let [[ref-only alt-only offset _] (diff-bases ref-seq alt-seq (dec pos))]
+  (let [alt-seq* (subs alt-seq 0 (min (count ref-seq) (count alt-seq)))
+        [ref-only alt-only offset _] (diff-bases ref-seq alt-seq* (dec pos))]
     (when (and (seq ref-only)
                (seq alt-only))
       {:ppos (+ pos offset)
        :pref (str (first ref-only))
        :palt (str (first alt-only))})))
+
+(defn- first-diff-aa-is-ter-site?
+  [pos ref-seq alt-seq]
+  (-> (get-first-diff-aa-info pos ref-seq alt-seq)
+      :pref
+      (= "*")))
 
 (defn- ->protein-variant
   [{:keys [strand] :as rg} pos ref alt
@@ -331,6 +338,9 @@
                                                             (= palt (subs pref 0 (count palt))))
                                                        (= (first palt-only) \*)) :fs-ter-substitution
                                                    ref-include-ter-site :indel
+                                                   (first-diff-aa-is-ter-site? ppos
+                                                                               ref-prot-seq
+                                                                               alt-prot-seq*) :extension
                                                    :else :frame-shift)
               (or (and (zero? nprefo) (zero? npalto))
                   (and (= nprefo 1) (= npalto 1))) :substitution
@@ -483,27 +493,33 @@
                                  (coord/unknown-coordinate))))))
 
 (defn- protein-extension
-  [ppos pref palt {:keys [ref-prot-seq alt-prot-seq alt-tx-prot-seq c-ter-adjusted-alt-prot-seq ini-offset]}]
+  [ppos pref palt {:keys [ref-prot-seq alt-tx-prot-seq c-ter-adjusted-alt-prot-seq ini-offset] :as seq-info}]
   (if (and (not= ppos 1)
            (ter-site-same-pos? ref-prot-seq c-ter-adjusted-alt-prot-seq))
     (mut/protein-no-effect)
     (let [[_ ins offset _] (diff-bases pref palt)
+          alt-prot-seq* (format-alt-prot-seq seq-info)
+          first-diff-aa-info (if (= ppos 1)
+                               {:ppos 1
+                                :pref "M"}
+                               (get-first-diff-aa-info ppos
+                                                       ref-prot-seq
+                                                       alt-prot-seq*))
           rest-seq (if (= ppos 1)
                      (-> alt-tx-prot-seq
                          (subs 0 ini-offset)
                          reverse
                          (#(apply str %)))
-                     (-> alt-tx-prot-seq
-                         (subs (+ ini-offset (count alt-prot-seq)))))
-          ter-site (some-> (string/index-of rest-seq (if (= ppos 1) "M" "*")) inc)]
+                     (subs alt-prot-seq* (:ppos first-diff-aa-info)))
+          new-aa-pos (some-> (string/index-of rest-seq (:pref first-diff-aa-info)) inc)]
       (mut/protein-extension (if (= ppos 1) "Met" "Ter")
                              (coord/protein-coordinate (if (= ppos 1) 1 (+ ppos offset)))
                              (mut/->long-amino-acid (if (= ppos 1)
                                                       (last ins)
-                                                      (or (last ins) (first rest-seq))))
+                                                      (:palt first-diff-aa-info)))
                              (if (= ppos 1) :upstream :downstream)
-                             (if ter-site
-                               (coord/protein-coordinate ter-site)
+                             (if new-aa-pos
+                               (coord/protein-coordinate new-aa-pos)
                                (coord/unknown-coordinate))))))
 
 (defn- mutation

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -278,9 +278,7 @@
 
 (defn- first-diff-aa-is-ter-site?
   [pos ref-seq alt-seq]
-  (-> (get-first-diff-aa-info pos ref-seq alt-seq)
-      :pref
-      (= "*")))
+  (= "*" (:pref (get-first-diff-aa-info pos ref-seq alt-seq))))
 
 (defn- ->protein-variant
   [{:keys [strand] :as rg} pos ref alt

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -174,6 +174,15 @@
       {:ppos 6 :pref "F" :palt "G"} "ABCDEG" 4
       {:ppos 13 :pref "M" :palt "K"} "ACBDEFGHIJKLK" 10)))
 
+(deftest first-diff-aa-is-ter-site?-test
+  (let [ref-seq "ABCDEFGHIJKLM*"]
+    (are [pred alt-seq pos] (pred (#'prot/first-diff-aa-is-ter-site? pos
+                                                                     ref-seq
+                                                                     alt-seq))
+      false? "ABCDEG" 1
+      true? "ABCDEFGHIJKLMNO" 1
+      true? "ABCDEFGHIJKLMNO*" 1)))
+
 (def ref-gene-EGFR
   {:bin 125
    :name "NM_005228"

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -244,6 +244,7 @@
         "chr2" 188974490 "A" "C" '("p.M1Lext-23")
         "chr2" 189011772 "T" "C" '("p.*1467Qext*45") ; cf. ClinVar 101338
         "chr11" 125655318 "TGA" "TAT" '("p.*477Yext*17" "p.*443Yext*17" "p.*477Yext*24")
+        "chr10" 8074014 "C" "CATGGGTT" '("p.*445Yext*64" "p.*444Yext*64") ; not actual example (+)
         ;; NOTE: There are very few correct examples...
 
         ;; Extension without termination site


### PR DESCRIPTION
I found conditional branch is not correct when `(not= ref-prot-rest alt-prot-rest)`.
And I found new termination site position and changed amino acid is not correct when ref doesn't include termination codon and alt is longer than ref in protein-extension.

So I added new extension conditional branch and fixed protein-extension hgvs create process more precisely.
