### PR TITLE
Add prefer-extension option for variant affects initial codon

### DIFF
--- a/src/varity/hgvs.clj
+++ b/src/varity/hgvs.clj
@@ -9,7 +9,9 @@
   [{:prefer-deletion? false}
    {:prefer-deletion? true}
    {:prefer-insertion? false}
-   {:prefer-insertion? true}])
+   {:prefer-insertion? true}
+   {:prefer-extension-for-initial-codon-alt? false}
+   {:prefer-extension-for-initial-codon-alt? true}])
 
 (defn- dispatch
   [ref-seq ref-gene]

--- a/src/varity/vcf_to_hgvs.clj
+++ b/src/varity/vcf_to_hgvs.clj
@@ -69,6 +69,7 @@
 (def ^:private default-options
   {:prefer-deletion? false
    :prefer-insertion? false
+   :prefer-extension-for-initial-codon-alt? false
    :tx-margin 5000
    :verbose? false})
 
@@ -160,6 +161,9 @@
     :prefer-insertion? Prefer insertion (e.g. \"c.H9_L10insRPH\") to repeated
                        sequences (e.g. \"c.R4_H6[3]\"), default false.
 
+    :prefer-extension-for-initial-codon-alt? Prefer extension to protein unknown variant
+                                             that affects initial codon, default false.
+
     :verbose?          Print debug information, default false."
   {:arglists '([variant ref-seq ref-gene]
                [variant ref-seq ref-gene options])}
@@ -229,6 +233,9 @@
 
     :prefer-insertion? Prefer insertion (e.g. \"c.9_10insAGG\") to repeated
                        sequences (e.g. \"c.4_6[3]\"), default false.
+
+    :prefer-extension-for-initial-codon-alt? Prefer extension to protein unknown variant
+                                             that affects initial codon, default false.
 
     :tx-margin         The length of transcription margin, up to a maximum of
                        10000, default 5000.

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -283,7 +283,7 @@
 (defn- ->protein-variant
   [{:keys [strand] :as rg} pos ref alt
    {:keys [ref-exon-seq ref-prot-seq alt-exon-seq alt-rg ref-include-ter-site] :as seq-info}
-   {:keys [prefer-deletion? prefer-insertion?]}]
+   {:keys [prefer-deletion? prefer-insertion? prefer-extension-for-initial-codon-alt?]}]
   (cond
     (= ref-exon-seq alt-exon-seq)
     {:type :no-effect, :pos 1, :ref nil, :alt nil}
@@ -326,7 +326,9 @@
               (= (+ base-ppos offset) (count ref-prot-seq)) (if (= "" pref-only palt-only)
                                                               :no-effect
                                                               :extension)
-              (= (+ base-ppos offset) 1) (if (= ref-prot-rest alt-prot-rest)
+              (= (+ base-ppos offset) 1) (if (or (= ref-prot-rest alt-prot-rest)
+                                                 (and prefer-extension-for-initial-codon-alt?
+                                                      (not= (first ref-prot-seq) (first alt-prot-seq*))))
                                            :extension
                                            :frame-shift)
               (and (pos? nprefo) (= (first palt-only) \*)) :substitution

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -266,6 +266,7 @@
         ;; unknown because variant affects utr/initiation site boundary
         ;; e.g. NM_007298:c.-19_80del from BRCA Share
         "chr17" 43124016 "CCAGATGGGACACTCTAAGATTTTCTGCATAGCATTAATGACATTTTGTACTTCTTCAACGCGAAGAGCAGATAAATCCATTTCTTTCTGTTCCAATGAA" "C" '("p.?")
+        "chr2" 197434979 "AGTCTTGGCGATCTTCGCCATTTT" "A" '("p.?")
 
         ;; unknwon because first amino acid of alt-prot-seq is M but variant affects utr/initiation site boundary in DNA level
         "chr7" 55019277 "GATGCGA" "ATG" '("p.?") ; not actual example (+)
@@ -292,7 +293,10 @@
         "chr1" 47438996 "T" "TCCGCAC" {:prefer-insertion? true} '("p.H293_A294insPH")
 
         ;; prefer-insertion?, not actual example (+)
-        "chr1" 26773690 "C" "CGCAGCA" {:prefer-insertion? true} '("p.Q1334_R1335insQQ"))))
+        "chr1" 26773690 "C" "CGCAGCA" {:prefer-insertion? true} '("p.Q1334_R1335insQQ")
+
+        ;; prefer-extension-for-initial-codon-alt?, not actual example (-)
+        "chr2" 197434979 "AGTCTTGGCGATCTTCGCCATTTT" "A" {:prefer-extension-for-initial-codon-alt? true} '("p.M1Sext-?"))))
 
   (cavia-testing "throws Exception if inputs are illegal"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]


### PR DESCRIPTION
I added prefer-extension option for variant that affects initial codon.