### PR TITLE
fix: fix apply-offset for first exon variant

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -187,7 +187,9 @@
                 apply-offset*))]
     (or (apply-offset* [[pos* pos*]])
         (and ref-include-ter-site (apply-ter-site-offset pos*))
-        (some (fn [[_ e]] (when (<= e pos*) e)) (reverse exon-ranges)))))
+        (some (fn [[_ e]] (when (<= e pos*) e)) (reverse exon-ranges))
+        (let [[s e] (first exon-ranges)] (when (<= s pos* e) pos*))
+        (let [[s e] (last exon-ranges)] (when (<= s pos* e) pos*)))))
 
 (defn- read-sequence-info
   [seq-rdr rg pos ref alt]

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -268,6 +268,10 @@
         "chr17" 43124016 "CCAGATGGGACACTCTAAGATTTTCTGCATAGCATTAATGACATTTTGTACTTCTTCAACGCGAAGAGCAGATAAATCCATTTCTTTCTGTTCCAATGAA" "C" '("p.?")
         "chr2" 197434979 "AGTCTTGGCGATCTTCGCCATTTT" "A" '("p.?")
 
+        ;; unknown because variant affects initiation site
+        "chr11" 118436512 "CATG" "C" '("p.?")
+        "chrX" 48791109 "CATG" "C" '("p.?")
+
         ;; unknwon because first amino acid of alt-prot-seq is M but variant affects utr/initiation site boundary in DNA level
         "chr7" 55019277 "GATGCGA" "ATG" '("p.?") ; not actual example (+)
 


### PR DESCRIPTION
I found cds-start is nil after apply-offset and it is first exon variant.
So I fixed apply-offset fn for first exon variant.