### PR TITLE
add UTR variant determine process

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -93,9 +93,11 @@
 
 (defn- is-deletion-variant?
   [ref alt]
-  (or (and (not= 1 (count ref)) (= 1 (count alt)))
-      (and (not= 1 (count ref) (count alt))
-           (not= (first ref) (first alt)))))
+  (let [[del ins offset _] (diff-bases ref alt)
+        ndel (count del)
+        nins (count ins)]
+    (and (<= 1 ndel) (or (= offset 1)
+                         (not= 1 ndel nins)))))
 
 (defn- is-insertion-variant?
   [ref alt]

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -44,8 +44,8 @@
     false? "T" "A" ; substitution
     true? "TAGTCTA" "T" ; deletion
     false? "T" "TGTGATC" ; insertion
-    true? "T" "GTCATCC" ; delins
-    true? "ATC" "CATGCAT" ; delins
+    true? "AT" "AGTCATCC" ; indel
+    true? "GATC" "GCATGCAT" ; indel
     ))
 
 (deftest is-insertion-variant?-test
@@ -53,8 +53,8 @@
     false? "T" "A" ; substitution
     false? "TAGTCTA" "T" ; deletion
     true? "T" "TGTGATC" ; insertion
-    false? "T" "GTCATCC" ; delins
-    false? "ATC" "CATGCAT" ; delins
+    false? "AT" "AGTCATCC" ; indel
+    false? "GATC" "GCATGCAT" ; indel
     ))
 
 (deftest cds-start-upstream-to-cds-variant?-test
@@ -135,10 +135,10 @@
                     :cds-end 20}]
     (are [p rg pos ref alt] (p (#'prot/include-utr-ini-site-boundary? rg pos ref alt))
       true? forward-rg 8 "CCAT" "C"
-      true? forward-rg 9 "CAT" "GGG"
+      true? forward-rg 8 "CCAT" "CGGG"
       false? forward-rg 9 "CAT" "C"
       true? reverse-rg 18 "CATGG" "C"
-      true? reverse-rg 20 "TGG" "ACC"
+      true? reverse-rg 19 "ATGG" "AACC"
       false? reverse-rg 20 "TGG" "T")))
 
 (deftest include-ter-site?-test
@@ -150,10 +150,10 @@
                     :cds-end 20}]
     (are [p rg pos ref alt] (p (#'prot/include-ter-site? rg pos ref alt))
       true? forward-rg 17 "ATG" "A"
-      true? forward-rg 20 "AG" "CC"
+      true? forward-rg 19 "GAG" "GCC"
       false? forward-rg 20 "AAT" "A"
       true? reverse-rg 9 "TT" "T"
-      true? reverse-rg 10 "ACT" "G"
+      true? reverse-rg 9 "AACT" "AG"
       false? reverse-rg 8 "AG" "A")))
 
 (deftest ter-site-same-pos?-test
@@ -171,25 +171,25 @@
       true? 9 "G" "T"
       true? 9 "G" "GA"
       true? 8 "GT" "G"
-      true? 9 "A" "TCG"
-      true? 8 "GT" "AGA"
+      true? 8 "TA" "TTCG"
+      true? 7 "CGT" "CAGA"
       false? 10 "A" "T"
       false? 10 "A" "AT"
       false? 10 "ATG" "A"
-      false? 10 "A" "TCG"
-      false? 9 "GAT" "AGA"
+      false? 9 "TA" "TTCG"
+      false? 8 "CGAT" "CAGA"
 
       ;; cds-end downstream
       true? 22 "G" "T"
       true? 21 "A" "AT"
       true? 21 "AT" "A"
-      true? 22 "G" "ATC"
-      true? 22 "GTC" "AGA"
+      true? 21 "AG" "AATC"
+      true? 21 "CGTC" "CAGA"
       false? 21 "A" "T"
       false? 20 "A" "AG"
       false? 20 "AA" "A"
-      false? 21 "A" "GCT"
-      false? 21 "ATA" "CG"
+      false? 20 "GA" "GGCT"
+      false? 20 "TATA" "TCG"
       )))
 
 (deftest apply-offset-test

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -44,7 +44,7 @@
     false? "T" "A" ; substitution
     true? "TAGTCTA" "T" ; deletion
     false? "T" "TGTGATC" ; insertion
-    true? "C" "GTCATCC" ; delins
+    true? "T" "GTCATCC" ; delins
     true? "ATC" "CATGCAT" ; delins
     ))
 
@@ -53,7 +53,7 @@
     false? "T" "A" ; substitution
     false? "TAGTCTA" "T" ; deletion
     true? "T" "TGTGATC" ; insertion
-    false? "C" "GTCATCC" ; delins
+    false? "T" "GTCATCC" ; delins
     false? "ATC" "CATGCAT" ; delins
     ))
 

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -48,6 +48,15 @@
     true? "ATC" "CATGCAT" ; delins
     ))
 
+(deftest is-insertion-variant?-test
+  (are [p ref alt] (p (#'prot/is-insertion-variant? ref alt))
+    false? "T" "A" ; substitution
+    false? "TAGTCTA" "T" ; deletion
+    true? "T" "TGTGATC" ; insertion
+    false? "C" "GTCATCC" ; delins
+    false? "ATC" "CATGCAT" ; delins
+    ))
+
 (deftest cds-start-upstream-to-cds-variant?-test
   (are [p cds-start pos ref] (p (#'prot/cds-start-upstream-to-cds-variant? cds-start pos ref))
     true? 100 99 "TCGA"
@@ -153,6 +162,35 @@
     true? "MTGA*" "MTGA*CT"
     false? "MTGA*" "MTGAQCT*"
     false? "MTGA*" "MTGA"))
+
+(deftest utr-variant?-test
+  (let [cds-start 10
+        cds-end 21]
+    (are [p pos ref alt] (p (#'prot/utr-variant? cds-start cds-end pos ref alt))
+      ;; cds-start upstream
+      true? 9 "G" "T"
+      true? 9 "G" "GA"
+      true? 8 "GT" "G"
+      true? 9 "A" "TCG"
+      true? 8 "GT" "AGA"
+      false? 10 "A" "T"
+      false? 10 "A" "AT"
+      false? 10 "ATG" "A"
+      false? 10 "A" "TCG"
+      false? 9 "GAT" "AGA"
+
+      ;; cds-end downstream
+      true? 22 "G" "T"
+      true? 21 "A" "AT"
+      true? 21 "AT" "A"
+      true? 22 "G" "ATC"
+      true? 22 "GTC" "AGA"
+      false? 21 "A" "T"
+      false? 20 "A" "AG"
+      false? 20 "AA" "A"
+      false? 21 "A" "GCT"
+      false? 21 "ATA" "CG"
+      )))
 
 (deftest apply-offset-test
   (let [pos 100

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -259,6 +259,8 @@
         "chr3" 149520808 "C" "CTTAA" '("p.=") ; not actual example (-)
         "chr17" 80090386 "CAGCACGTGCATGAACAACACAGGACACACACAGCACGTGCATGAACAACACAGGACACACACA" "C" '("p.=") ; not actural example (+)
         "chr11" 14279340 "G" "A" '("p.=") ; not actual example (-)
+        "chr7" 55019277 "G" "GTC" '("p.=") ; not actual example (+)
+        "chr17" 21042835 "T" "TG" '("p.=") ; not actual example (-)
 
         ;; unknown
         "chr12" 40393453 "G" "A" '("p.?") ; not actual example (+)


### PR DESCRIPTION
I added UTR variant determine process because some UTR variants were determined to affect protein-alteration.
e.g. `c.-1_1ins` variant

And I fixed deletion-variant determine fn more precisely.