### PR TITLE
fix read-seq-info and termination site variant condition

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -119,14 +119,16 @@
       (subs alt-down-exon-seq* 0 (- nalt-down-exon-seq (mod nalt-down-exon-seq 3))))))
 
 (defn- make-ter-site-adjusted-alt-seq
-  [alt-exon-seq alt-up-exon-seq alt-down-exon-seq strand cds-start cds-end pos ref]
+  [alt-exon-seq alt-up-exon-seq alt-down-exon-seq strand cds-start cds-end pos ref ref-include-ter-site]
   (cond
     (and (= strand :forward)
-         (cds-to-cds-end-downstream-variant? cds-end pos ref))
+         (or (cds-to-cds-end-downstream-variant? cds-end pos ref)
+             ref-include-ter-site))
     (str alt-exon-seq alt-down-exon-seq)
 
     (and (= strand :reverse)
-         (cds-start-upstream-to-cds-variant? cds-start pos ref))
+         (or (cds-start-upstream-to-cds-variant? cds-start pos ref)
+             ref-include-ter-site))
     (str alt-up-exon-seq alt-exon-seq)
 
     :else
@@ -256,7 +258,7 @@
           alt-up-exon-seq (make-alt-up-exon-seq alt-up-exon-seq tx-start (dec alt-cds-start) alt-exon-ranges* strand)
           alt-down-exon-seq (make-alt-down-exon-seq alt-down-exon-seq (inc alt-cds-end) alt-tx-end alt-exon-ranges* strand)
           ter-site-adjusted-alt-seq (make-ter-site-adjusted-alt-seq alt-cds-exon-seq alt-up-exon-seq alt-down-exon-seq
-                                                                    strand cds-start cds-end pos ref)]
+                                                                    strand cds-start cds-end pos ref ref-include-ter-site)]
       {:ref-exon-seq ref-cds-exon-seq
        :ref-prot-seq (codon/amino-acid-sequence (cond-> ref-cds-exon-seq
                                                   (= strand :reverse) util-seq/revcomp))

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -150,12 +150,48 @@
       true? reverse-rg 9 "AACT" "AG"
       false? reverse-rg 8 "AG" "A")))
 
+(deftest ref-include-from-ter-start-and-over-ter-end?-test
+  (let [cds-start 10
+        cds-end 21]
+    (are [p strand pos ref alt] (p (#'prot/ref-include-from-ter-start-and-over-ter-end? {:strand strand
+                                                                                         :cds-start cds-start
+                                                                                         :cds-end cds-end}
+                                                                                        pos
+                                                                                        ref
+                                                                                        alt))
+      true? :forward 18 "ATAA" "A"
+      true? :forward 18 "ATAAG" "AGC"
+      true? :reverse 9 "GTCA" "G"
+      true? :reverse 8 "CGTCA" "CTG"
+      false? :forward 18 "A" "T"
+      false? :forward 19 "T" "TCCCT"
+      false? :forward 18 "ATA" "A"
+      false? :reverse 10 "T" "A"
+      false? :reverse 11 "C" "CATG"
+      false? :reverse 8 "CGTC" "C")))
+
 (deftest ter-site-same-pos?-test
   (are [p ref alt] (p (#'prot/ter-site-same-pos? ref alt))
     true? "MTGA*" "MTGA*"
     true? "MTGA*" "MTGA*CT"
     false? "MTGA*" "MTGAQCT*"
     false? "MTGA*" "MTGA"))
+
+(deftest cds-variant?-test
+  (let [cds-start 10
+        cds-end 21]
+    (are [p pos ref alt] (p (#'prot/cds-variant? cds-start cds-end pos ref alt))
+      true? 10 "A" "A"
+      true? 10 "A" "ACT"
+      true? 9 "GATG" "G"
+      true? 10 "ATG" "AGC"
+      true? 21 "A" "T"
+      true? 20 "A" "ATC"
+      true? 20 "AA" "A"
+      false? 8 "CGA" "CTT"
+      false? 9 "C" "CGGT"
+      false? 20 "AAG" "ATC"
+      false? 21 "A" "AGC")))
 
 (deftest utr-variant?-test
   (let [cds-start 10
@@ -184,6 +220,23 @@
       false? 20 "AA" "A"
       false? 20 "GA" "GGCT"
       false? 20 "TATA" "TCG")))
+
+(deftest frameshift-within-cds?-test
+  (let [cds-start 10
+        cds-end 21]
+    (are [p pos ref alt] (p (#'prot/frameshift-within-cds? {:cds-start cds-start
+                                                            :cds-end cds-end}
+                                                           pos
+                                                           ref
+                                                           alt))
+      true? 13 "T" "TC"
+      true? 15 "AGCTC" "A"
+      true? 18 "GC" "GGA"
+      false? 15 "A" "T"
+      false? 11 "T" "TGCT"
+      false? 10 "ATGGCTC" "A"
+      false? 8 "GTATG" "G"
+      false? 20 "GTAAC" "GCTTA")))
 
 (deftest get-alt-cds-start-pos-test
   (let [cds-start 40

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -98,24 +98,27 @@
         upstream-seq "YYYYYY"
         downstream-seq "ZZZZZZ"
         [cds-start cds-end] [7 12]]
-    (are [p strand pos ref] (#'prot/make-ter-site-adjusted-alt-seq alt-seq
-                                                                   upstream-seq
-                                                                   downstream-seq
-                                                                   strand
-                                                                   cds-start
-                                                                   cds-end
-                                                                   pos
-                                                                   ref)
-      "XXXXXX" :forward 8 "XX"
-      "XXXXXX" :forward 5 "YY"
-      "XXXXXX" :forward 5 "YYX"
-      "XXXXXX" :forward 13 "ZZ"
-      "XXXXXXZZZZZZ" :forward 12 "XZZ"
-      "XXXXXX" :reverse 8 "XX"
-      "XXXXXX" :reverse 5 "YY"
-      "YYYYYYXXXXXX" :reverse 5 "YYX"
-      "XXXXXX" :reverse 13 "ZZ"
-      "XXXXXX" :reverse 12 "XZZ")))
+    (are [p strand pos ref ref-include-ter-site] (= p (#'prot/make-ter-site-adjusted-alt-seq alt-seq
+                                                                                             upstream-seq
+                                                                                             downstream-seq
+                                                                                             strand
+                                                                                             cds-start
+                                                                                             cds-end
+                                                                                             pos
+                                                                                             ref
+                                                                                             ref-include-ter-site))
+      "XXXXXX" :forward 8 "XX" false
+      "XXXXXX" :forward 5 "YY" false
+      "XXXXXX" :forward 5 "YYX" false
+      "XXXXXX" :forward 13 "ZZ" false
+      "XXXXXXZZZZZZ" :forward 10 "XX" true
+      "XXXXXXZZZZZZ" :forward 12 "XZZ" true
+      "YYYYYYXXXXXX" :reverse 8 "XX" true
+      "YYYYYYXXXXXX" :reverse 9 "XX" true
+      "XXXXXX" :reverse 5 "YY" false
+      "YYYYYYXXXXXX" :reverse 5 "YYX" true
+      "XXXXXX" :reverse 13 "ZZ" false
+      "XXXXXX" :reverse 12 "XZZ" false)))
 
 (deftest include-utr-ini-site-boundary?-test
   (let [forward-rg {:strand :forward

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -183,8 +183,8 @@
   (cavia-testing "returns protein HGVS strings"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [chr pos ref alt e]
-          (= (vcf-variant->protein-hgvs-texts {:chr chr, :pos pos, :ref ref, :alt alt}
-                                              test-ref-seq-file rgidx) e)
+           (= (vcf-variant->protein-hgvs-texts {:chr chr, :pos pos, :ref ref, :alt alt}
+                                               test-ref-seq-file rgidx) e)
         ;; Substitution
         "chr7" 55191822 "T" "G" '("p.L858R") ; cf. rs121434568
         "chr1" 11796321 "G" "A" '("p.A222V") ; cf. rs1801133
@@ -213,6 +213,9 @@
         "chr3" 73062352 "T" "TTGG" '("p.=" "p.L91_E92insV") ; cf. rs143235716 (+)
         "chr3" 122740443 "G" "GAGA" '("p.P456_Q457insS"
                                       "p.P428_Q429insS") ; cf. rs71270423 (-)
+
+        ;; deletion includes stop codon deletion
+        "chr17" 9771484 "GCAGTTACC" "G" '("p.E310_G311insAGGQMGHPLEIKVFLA" "p.E311_G312insAGGQMGHPLEIKVFLA") ; not actual example(-)
 
         ;; indel
         "chr2" 47445589 "CTTACTGAT" "CCC" '("p.L440_D442delinsP" "p.L374_D376delinsP") ; cf. rs63749931 (+)
@@ -279,7 +282,6 @@
 
         ;; unknown because variant includes termination site and alternative termination site is not found
         "chr17" 81537074 "GTACTGAGGC" "G" '("p.?") ; not actual example(+)
-        "chr17" 9771484 "GCAGTTACC" "G" '("p.?") ; not actual example(-)
         )))
 
   (cavia-testing "options"

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -221,8 +221,20 @@
         "chr2" 47445589 "CTTACTGAT" "CCC" '("p.L440_D442delinsP" "p.L374_D376delinsP") ; cf. rs63749931 (+)
         "chr1" 152111364 "TGC" "TCG" '("p.E617_Q618delinsDE") ; cf. rs35444647 (-)
 
-        ;; indel include stop codon deletion
+        ;; indel includes stop codon deletion
         "chr8" 116847497 "TCCTTATATAATATGGAACCTTGGTCCAGGTGTTGCGATGATGTCACTGTA" "T" '("p.Y617_I631delinsS")
+        "chr17" 43045678 "TCAGTAG" "T" '("p.H758delinsQLQPATGTEPQDPKNELTKWPFQALGAPLTLQSFYCPG"
+                                         "p.H1815delinsQLQPATGTEPQDPKNELTKWPFQALGAPLTLQSFYCPG"
+                                         "p.H1862delinsQLQPATGTEPQDPKNELTKWPFQALGAPLTLQSFYCPG"
+                                         "p.H1883delinsQLQPATGTEPQDPKNELTKWPFQALGAPLTLQSFYCPG") ; not actual example (-)
+        "chr17" 43045679 "CAGTAGT" "C" '("p.H758delinsRLQPATGTEPQDPKNELTKWPFQALGAPLTLQSFYCPG"
+                                         "p.H1815delinsRLQPATGTEPQDPKNELTKWPFQALGAPLTLQSFYCPG"
+                                         "p.H1862delinsRLQPATGTEPQDPKNELTKWPFQALGAPLTLQSFYCPG"
+                                         "p.H1883delinsRLQPATGTEPQDPKNELTKWPFQALGAPLTLQSFYCPG") ; not actual example (-)
+        "chr10" 87965467 "GTCT" "G" '("p.V403delinsGIFFYQEG" "p.V576delinsGIFFYQEG" "p.V206delinsGIFFYQEG") ; not actual example (+)
+        "chr10" 87965464 "AAAGTCT" "A" '("p.K402_V403delinsRIFFYQEG" "p.K575_V576delinsRIFFYQEG" "p.K205_V206delinsRIFFYQEG") ; not actual example (+)
+        "chr13" 24421120 "TAGC" "T" '("p.G1724delinsEVK") ; not actual example (-)
+        "chr13" 24421120 "TAGCCTT" "T" '("p.G1724delinsVK") ; not actual example (-)
 
         ;; repeated sequences
         "chr1" 47438996 "T" "TCCGCAC" '("p.P286_H287[5]") ; cf. rs3046924 (+)
@@ -236,6 +248,8 @@
                                           "p.S1415Ifs*2") ; https://github.com/chrovis/varity/issues/58
         "chr17" 31261816 "CC" "C" '("p.N1542Tfs*11" "p.N1563Tfs*11") ; cf. rs1555619041 (+)
         "chr1" 16138274 "CG" "C" '("p.R327Dfs*66")
+        "chr3" 149520807 "ACAGC" "A" '("p.W399Cfs*62") ; not actual example (-)
+
         ;; initiation site is affected in DNA level but initiation site is not changed in protein level
         "chr7" 55019279 "TGC" "T" '("p.R2Tfs*34") ; not actual example (+)
         "chr11" 32396363 "C" "CGACCGTACAA" '("p.A170Cfs*6" "p.A153Cfs*6" "p.A365Cfs*6" "p.A382Cfs*6") ; not actual example (-)
@@ -244,16 +258,32 @@
         "chr17" 81537070 "G" "GTA" '("p.W514Cfs*?" "p.W490Cfs*?") ; not actual example (+)
         "chr17" 9771493 "CCT" "C" '("p.E310Gfs*?" "p.E311Gfs*?") ; not actual example (-)
 
+        ;; Frame shift includes termination site deletion
+        "chr17" 43045679 "CAGTAG" "C" '("p.H758Qfs*16" "p.H1815Qfs*16" "p.H1862Qfs*16" "p.H1883Qfs*16") ;; not actual example (-)
+        "chr13" 24421120 "TAGCC" "T" '("p.G1724Kfs*8") ; not actual example (-)
+        "chr13" 24421120 "TAGCCT" "T" '("p.G1724Sfs*36") ; not actual example (-)
+        "chr13" 24421120 "TAGCCTTG" "T" '("p.Q1723Kfs*8") ; not actual example (-)
+        "chr10" 87965466 "AGTCT" "A" '("p.V403Efs*12" "p.V576Efs*12" "p.V206Efs*12") ; not actual example (+)
+        "chr10" 87965465 "AAGTCT" "A" '("p.V403Nfs*17" "p.V576Nfs*17" "p.V206Nfs*17") ; not actual example (+)
+        "chr10" 87965463 "AAAAGTCT" "A" '("p.K402Efs*12" "p.K575Efs*12" "p.K205Efs*12") ; not actual example (+)
+
         ;; Extension
         "chr2" 188974490 "A" "C" '("p.M1Lext-23")
         "chr2" 189011772 "T" "C" '("p.*1467Qext*45") ; cf. ClinVar 101338
         "chr11" 125655318 "TGA" "TAT" '("p.*477Yext*17" "p.*443Yext*17" "p.*477Yext*24")
         "chr10" 8074014 "C" "CATGGGTT" '("p.*445Yext*64" "p.*444Yext*64") ; not actual example (+)
+        "chr10" 87965468 "TC" "T" '("p.*404Eext*11" "p.*577Eext*11" "p.*207Eext*11") ; not actual example (+)
         ;; NOTE: There are very few correct examples...
 
         ;; Extension without termination site
         "chr17" 81537077 "CT" "C" '("p.*517Eext*?" "p.*493Eext*?") ; not actual example (+)
         "chr17" 9771487 "GT" "G" '("p.*312Yext*?" "p.*313Yext*?") ; not actual example (-)
+
+        ;; Extension includes termination site deletion
+        "chr13" 24421117 "ACTT" "A" '("p.*1725Fext*2") ; not actual example (-)
+        "chr13" 24421116 "GACTT" "G" '("p.*1725Sext*6") ; not actual example (-)
+        "chr13" 24421117 "ACT" "A" '("p.*1725Yext*35") ; not actual example (-)
+        "chr13" 24421116 "GACT" "G" '("p.*1725Yext*2") ; not actual example (-)
 
         ;; no effect
         "chr7" 55181876 "A" "T" '("p.=") ; not actual example (+)


### PR DESCRIPTION
To determine type of protein alteration that includes termination site more precisely, I fixed alt-seq create process and protein alteration type determine process.
I executed `lein test :slow` and I confirmed pass all tests.

- 9298a767a7eae41395c6f20c3b99f0e9f937fe54: First, check overlap-exon-intron-boundary because we don't need other information when variant overlaps exon/intron boundary.
- 75170d4f6c82d7d22bcfafeb2a1840aebf1eb51b: Change to make alt-seq process more precisely. Change `apply-offset` fn and use it to make alt seq.
- 9bb63a8bf0096de2adfc37616844c292b2488849: Fix process of ter-site-adjusted-alt-seq because it is also used when variant includes termination site.
- af8ddc9a3bbc091ab944fe76909368ea6c859f76: Just change ther order of protein-indel-fn.
- 683c8189e3bbaaf58cbbe3b6221785d7f840a959: Fix protein alteration type determine process that variant includes termination site when variant is determined as indel at first.