### PR TITLE
Fix the dispatcher to check if an arg extends the varity.ref_gene.GeneAnnotationIndex protocol

### DIFF
--- a/src/varity/hgvs.clj
+++ b/src/varity/hgvs.clj
@@ -21,7 +21,7 @@
     (io-util/sequence-reader? ref-seq)
     (cond
       (string? ref-gene) :ref-gene-path
-      (instance? varity.ref_gene.RefGeneIndex ref-gene) :ref-gene-index
+      (instance? varity.ref_gene.GeneAnnotationIndex ref-gene) :ref-gene-index
       (map? ref-gene) :ref-gene-entity)))
 
 (defmulti find-aliases

--- a/src/varity/hgvs_to_vcf.clj
+++ b/src/varity/hgvs_to_vcf.clj
@@ -15,7 +15,7 @@
     (io-util/sequence-reader? ref-seq)
     (cond
       (string? ref-gene) :ref-gene-path
-      (instance? varity.ref_gene.RefGeneIndex ref-gene) :ref-gene-index
+      (instance? varity.ref_gene.GeneAnnotationIndex ref-gene) :ref-gene-index
       (map? ref-gene) :ref-gene-entity)))
 
 (defn- coding-dna-hgvs->vcf-variants

--- a/src/varity/vcf_to_hgvs.clj
+++ b/src/varity/vcf_to_hgvs.clj
@@ -23,7 +23,7 @@
     (io-util/sequence-reader? ref-seq)
     (cond
       (string? ref-gene) :ref-gene-path
-      (instance? varity.ref_gene.RefGeneIndex ref-gene) :ref-gene-index
+      (instance? varity.ref_gene.GeneAnnotationIndex ref-gene) :ref-gene-index
       (map? ref-gene) :ref-gene-entity)))
 
 (defn- coding-dna-ref-gene? [rg]


### PR DESCRIPTION
I have updated some dispatchers to check if an argument is not an instance of varity.ref_gene.RefGeneIndex *record*, but extends varity.ref_gene.GeneAnnotationIndex *protocol*.