### PR TITLE
NullPointerException case in vcf-variant->hgvs

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -333,6 +333,11 @@
                    (count ref-exon-seq) (:name rg) (:name2 rg))
         {:type :unknown, :pos nil, :ref nil, :alt nil})
 
+    (not= (last ref-prot-seq) \*)
+    (do (log/warnf "Last codon is not stop codon: %s (%s, %s)"
+                   (str (last ref-prot-seq)) (:name rg) (:name2 rg))
+        {:type :unknown, :pos nil, :ref nil, :alt nil})
+
     :else
     (let [alt-prot-seq* (format-alt-prot-seq seq-info)
           ppos (protein-position pos rg)


### PR DESCRIPTION
Resolve #107 

I found  last codon of some transcripts are not stop codon.
So I return unknown when these transcripts.