### PR TITLE
Support uncertain base and amino acid

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :min-lein-version "2.7.0"
   :dependencies [[org.clojure/clojure "1.11.1" :scope "provided"]
                  [org.clojure/tools.logging "1.2.4"]
-                 [clj-hgvs "0.4.6"]
+                 [clj-hgvs "0.5.0"]
                  [cljam "0.8.3"]
                  [org.apache.commons/commons-compress "1.21"]
                  [proton "0.2.2"]]

--- a/src/varity/codon.clj
+++ b/src/varity/codon.clj
@@ -3,7 +3,7 @@
   (:require [clojure.string :as string]))
 
 ;; See https://en.wikipedia.org/wiki/DNA_codon_table
-(def ^:private codon-amino-acid-map
+(def ^:private codon-amino-acid-map*
   {"TTT" "F"
    "TTC" "F"
    "TTA" "L"
@@ -68,6 +68,18 @@
    "GGC" "G"
    "GGA" "G"
    "GGG" "G"})
+
+(def ^:private uncertain-codon-map
+  (let [bases ["A" "T" "G" "C" "N"]
+        uncertain-base "N"
+        other-base-combinations (mapcat #(map (fn [b] (vector % b)) bases) bases)
+        first-uncertain-base-codons (map #(str uncertain-base (first %) (second %)) other-base-combinations)
+        second-uncertain-base-codons (map #(str (first %) uncertain-base (second %)) other-base-combinations)
+        third-uncertain-base-codons (map #(str (first %) (second %) uncertain-base) other-base-combinations)
+        uncertain-codons (set (concat first-uncertain-base-codons second-uncertain-base-codons third-uncertain-base-codons))]
+    (into {} (map #(vector % "X") uncertain-codons))))
+
+(def codon-amino-acid-map (merge codon-amino-acid-map* uncertain-codon-map))
 
 (def ^:private amino-acid-codon-map
   (->> (group-by second codon-amino-acid-map)

--- a/src/varity/codon.clj
+++ b/src/varity/codon.clj
@@ -72,7 +72,7 @@
 (def ^:private uncertain-codon-map
   (let [bases ["A" "T" "G" "C" "N"]
         uncertain-base "N"
-        other-base-combinations (mapcat #(map (fn [b] (vector % b)) bases) bases)
+        other-base-combinations (for [a bases b bases] (vector a b))
         first-uncertain-base-codons (map #(str uncertain-base (first %) (second %)) other-base-combinations)
         second-uncertain-base-codons (map #(str (first %) uncertain-base (second %)) other-base-combinations)
         third-uncertain-base-codons (map #(str (first %) (second %) uncertain-base) other-base-combinations)

--- a/test/varity/hgvs_to_vcf_test.clj
+++ b/test/varity/hgvs_to_vcf_test.clj
@@ -151,6 +151,10 @@
         "c.477_478insT" "OR4F5" '({:chr "chr1", :pos 69567, :ref "A", :alt "AT"})
         "c.1368_1369insTCT" "HSPBAP1" '({:chr "chr3", :pos 122740443, :ref "G", :alt "GAGA"}
                                         {:chr "chr3", :pos 122740359, :ref "C", :alt "CAGA"}) ; cf. rs16338 (-)
+        "c.1368_1369insNNN" "HSPBAP1" '({:chr "chr3", :pos 122740443, :ref "G", :alt "GNNN"}
+                                        {:chr "chr3", :pos 122740359, :ref "C", :alt "CNNN"})
+        "c.1368_1369insN[3]" "HSPBAP1" '({:chr "chr3", :pos 122740443, :ref "G", :alt "GNNN"}
+                                         {:chr "chr3", :pos 122740359, :ref "C", :alt "CNNN"})
 
         ;; inversion
         "c.4002-31_4002-8inv" "MSH6" '({:chr "chr2", :pos 47806747, :ref "AAAACTTTTTTTTTTTTTTTTTTAA", :alt "ATTAAAAAAAAAAAAAAAAAAGTTT"}) ; cf. rs267608133 (+)
@@ -158,6 +162,8 @@
         ;; indel
         "c.385_386delAGinsGTT" "MLH1" '({:chr "chr3", :pos 37006994, :ref "AAG", :alt "AGTT"}) ; cf. rs63751710 (+)
         "c.862_863delCAinsG" "HSPG2" '({:chr "chr1", :pos 21887514, :ref "CTG", :alt "CC"}) ; cf. rs2010297 (-)
+        "c.862_863delCAinsNNN" "HSPG2" '({:chr "chr1", :pos 21887514, :ref "CTG", :alt "CNNN"})
+        "c.862_863delCAinsN[3]" "HSPG2" '({:chr "chr1", :pos 21887514, :ref "CTG", :alt "CNNN"})
 
         ;; repeated sequences
         "c.2571_2573[3]" "EGFR" '({:chr "chr7", :pos 55191819, :ref "G", :alt "GGCTGCT"})
@@ -197,6 +203,10 @@
         "c.477_478insT" "OR4F5" '({:alt "GT", :chr "chr1", :pos 69504, :ref "G"})
         "c.1368_1369insTCT" "HSPBAP1" '({:chr "chr3", :pos 122740443, :ref "G", :alt "GAGA"}
                                         {:chr "chr3", :pos 122740359, :ref "C", :alt "CAGA"})
+        "c.1368_1369insNNN" "HSPBAP1" '({:chr "chr3", :pos 122740443, :ref "G", :alt "GNNN"}
+                                        {:chr "chr3", :pos 122740359, :ref "C", :alt "CNNN"})
+        "c.1368_1369insN[3]" "HSPBAP1" '({:chr "chr3", :pos 122740443, :ref "G", :alt "GNNN"}
+                                         {:chr "chr3", :pos 122740359, :ref "C", :alt "CNNN"})
 
         ;; inversion
         "c.4002-31_4002-8inv" "MSH6" '({:chr "chr2", :pos 47806747, :ref "AAAACTTTTTTTTTTTTTTTTTTAA", :alt "ATTAAAAAAAAAAAAAAAAAAGTTT"})
@@ -206,6 +216,8 @@
                                         {:alt "AGTT", :chr "chr3", :pos 37006994, :ref "AAG"}
                                         {:alt "CGTT", :chr "chr3", :pos 37026005, :ref "CAG"})
         "c.862_863delCAinsG" "HSPG2" '({:chr "chr1", :pos 21887514, :ref "CTG", :alt "CC"})
+        "c.862_863delCAinsNNN" "HSPG2" '({:chr "chr1", :pos 21887514, :ref "CTG", :alt "CNNN"})
+        "c.862_863delCAinsN[3]" "HSPG2" '({:chr "chr1", :pos 21887514, :ref "CTG", :alt "CNNN"})
 
         ;; repeated sequences
         "c.2571_2573[3]" "EGFR" '({:alt "TGACGAC", :chr "chr7", :pos 55198720, :ref "T"}

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -21,8 +21,8 @@
   (cavia-testing "returns coding DNA HGVS strings"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]
       (are [chr pos ref alt e]
-          (= (vcf-variant->coding-dna-hgvs-texts {:chr chr, :pos pos, :ref ref, :alt alt}
-                                                 test-ref-seq-file rgidx) e)
+           (= (vcf-variant->coding-dna-hgvs-texts {:chr chr, :pos pos, :ref ref, :alt alt}
+                                                  test-ref-seq-file rgidx) e)
         ;; Substitution
         "chr7" 55191822 "T" "G" '("NM_005228:c.2573T>G") ; cf. rs121434568 (+)
         "chr1" 11796321 "G" "A" '("NM_005957:c.665C>T") ; cf. rs1801133 (-)
@@ -110,6 +110,8 @@
         "chr1" 69567 "A" "AT" '("NM_001005484:c.477_478insT")
         "chr3" 122740443 "G" "GAGA" '("NM_024610:c.1368_1369insTCT"
                                       "NM_001320728:c.1284_1285insTCT") ; cf. rs16338 (-)
+        "chr3" 122740443 "G" "GNNN" '("NM_024610:c.1368_1369insNNN"
+                                      "NM_001320728:c.1284_1285insNNN")
 
         ;; inversion
         "chr2" 47806747 "AAAACTTTTTTTTTTTTTTTTTTAA" "ATTAAAAAAAAAAAAAAAAAAGTTT"
@@ -131,6 +133,8 @@
                                        "NM_001258274:c.-339_-338delAGinsGTT") ; cf. rs63751710 (+)
         "chr1" 21887514 "CTG" "CC" '("NM_001291860:c.862_863delCAinsG"
                                      "NM_005529:c.862_863delCAinsG") ; cf. rs2010297 (-)
+        "chr1" 21887514 "CTG" "CN" '("NM_001291860:c.862_863delCAinsN"
+                                     "NM_005529:c.862_863delCAinsN")
 
         ;; repeated sequences
         "chr7" 55191822 "T" "TGCTGCT" '("NM_005228:c.2572_2574[3]") ; not actual example (+)
@@ -213,10 +217,13 @@
         "chr3" 73062352 "T" "TTGG" '("p.=" "p.L91_E92insV") ; cf. rs143235716 (+)
         "chr3" 122740443 "G" "GAGA" '("p.P456_Q457insS"
                                       "p.P428_Q429insS") ; cf. rs71270423 (-)
+        "chr3" 122740443 "G" "GNNN" '("p.P456_Q457insX"
+                                      "p.P428_Q429insX")
 
         ;; indel
         "chr2" 47445589 "CTTACTGAT" "CCC" '("p.L440_D442delinsP" "p.L374_D376delinsP") ; cf. rs63749931 (+)
         "chr1" 152111364 "TGC" "TCG" '("p.E617_Q618delinsDE") ; cf. rs35444647 (-)
+        "chr2" 47445589 "CTTACTGAT" "CNN" '("p.L440_D442delinsX" "p.L374_D376delinsX")
 
         ;; indel include stop codon deletion
         "chr8" 116847497 "TCCTTATATAATATGGAACCTTGGTCCAGGTGTTGCGATGATGTCACTGTA" "T" '("p.Y617_I631delinsS")


### PR DESCRIPTION
I bumped up [clj-hgvs](https://github.com/chrovis/clj-hgvs/tree/master) to 0.5.0 and supported uncertain base and amino acid.