### PR TITLE
Fix ini site affected variant determine process

### DIFF
--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -57,6 +57,7 @@
                                 dele (dec (+ tpos d))]
                             (cond
                               (< dele s) [(- s d) (- e d)]
+                              (= s e dels dele) [dels dele]
                               (<= dels s) (when (< dele e) [dels (- e d)])
                               (<= dels e) (if (< dele e)
                                             [s (- e d)]
@@ -297,11 +298,10 @@
 
 (defn- apply-offset
   [pos ref alt cds-start cds-end exon-ranges pos*]
-  (let [[del ins offset _] (diff-bases ref alt)
+  (let [[del _ offset _] (diff-bases ref alt)
         ndel (count del)
-        nins (count ins)
         pos-start (+ pos offset)
-        pos-end (+ pos-start (if (or (= 1 ndel nins) (zero? ndel)) 0 ndel))
+        pos-end (+ pos-start (if (zero? ndel) 0 (dec ndel)))
         apply-offset* (fn [exon-ranges*]
                         (ffirst (alt-exon-ranges exon-ranges* pos ref alt)))
         pos** (cond (and (= pos* cds-start) (<= pos-start cds-start pos-end))

--- a/src/varity/vcf_to_hgvs/protein.clj
+++ b/src/varity/vcf_to_hgvs/protein.clj
@@ -338,13 +338,15 @@
           alt-down-exon-seq (make-alt-down-exon-seq alt-down-exon-seq (inc alt-cds-end) alt-tx-end alt-exon-ranges* strand)
           ter-site-adjusted-alt-seq (make-ter-site-adjusted-alt-seq alt-cds-exon-seq alt-up-exon-seq alt-down-exon-seq
                                                                     strand cds-start cds-end pos ref ref-include-ter-site)
-          in-frame (in-frame? pos ref alt rg)]
-      {:ref-exon-seq ref-cds-exon-seq
-       :ref-prot-seq (codon/amino-acid-sequence (cond-> ref-cds-exon-seq
-                                                  (= strand :reverse) util-seq/revcomp))
-       :alt-exon-seq alt-cds-exon-seq
-       :alt-prot-seq (codon/amino-acid-sequence (cond-> alt-cds-exon-seq
-                                                  (= strand :reverse) util-seq/revcomp))
+          in-frame (in-frame? pos ref alt rg)
+          ref-cds-exon-seq* (cond-> ref-cds-exon-seq
+                              (= strand :reverse) util-seq/revcomp)
+          alt-cds-exon-seq* (cond-> alt-cds-exon-seq
+                              (= strand :reverse) util-seq/revcomp)]
+      {:ref-exon-seq ref-cds-exon-seq*
+       :ref-prot-seq (codon/amino-acid-sequence ref-cds-exon-seq*)
+       :alt-exon-seq alt-cds-exon-seq*
+       :alt-prot-seq (codon/amino-acid-sequence alt-cds-exon-seq*)
        :alt-tx-prot-seq (codon/amino-acid-sequence
                          (cond-> (str alt-up-exon-seq alt-cds-exon-seq alt-down-exon-seq)
                            (= strand :reverse) util-seq/revcomp))
@@ -367,7 +369,8 @@
        :ref-include-from-ter-upstream-and-over-ter-end ref-include-from-ter-upstream-and-over-ter-end
        :frameshift-within-cds frameshift-within-cds
        :utr-variant (utr-variant? cds-start cds-end pos ref alt)
-       :in-frame in-frame})))
+       :in-frame in-frame
+       :ini-site-affected (ini-site-affected? ref-cds-exon-seq* alt-cds-exon-seq*)})))
 
 (defn- protein-position
   "Converts genomic position to protein position. If pos is outside of CDS,
@@ -420,7 +423,7 @@
 (defn- ->protein-variant
   [{:keys [strand] :as rg} pos ref alt
    {:keys [ref-exon-seq ref-prot-seq alt-exon-seq alt-rg ref-include-ter-site
-           ref-include-from-ter-start-and-over-ter-end utr-variant] :as seq-info}
+           ref-include-from-ter-start-and-over-ter-end utr-variant ini-site-affected] :as seq-info}
    {:keys [prefer-deletion? prefer-insertion? prefer-deletion-insertion?
            prefer-extension-for-initial-codon-alt?]}]
   (cond
@@ -439,6 +442,10 @@
     (do (log/warnf "Last codon is not stop codon: %s (%s, %s)"
                    (str (last ref-prot-seq)) (:name rg) (:name2 rg))
         {:type :unknown, :pos nil, :ref nil, :alt nil})
+
+    (and (not prefer-extension-for-initial-codon-alt?)
+         ini-site-affected)
+    {:type :unknown, :pos nil, :ref nil, :alt nil}
 
     :else
     (let [alt-prot-seq* (format-alt-prot-seq seq-info)
@@ -467,7 +474,6 @@
                                                      (+ base-ppos offset)
                                                      pref-only
                                                      palt-only)
-          ini-site-affected (ini-site-affected? ref-exon-seq alt-exon-seq)
           first-diff-aa-is-ter-site (first-diff-aa-is-ter-site? base-ppos
                                                                 ref-prot-seq
                                                                 alt-prot-seq*)
@@ -478,17 +484,10 @@
                                                                      (ter-site-same-pos? ref-prot-seq alt-prot-seq*))
                                                               :no-effect
                                                               :extension)
-              (= (+ base-ppos offset) 1) (cond
-                                           (and (not prefer-extension-for-initial-codon-alt?)
-                                                ini-site-affected)
-                                           :unknown
-
-                                           (or (= ref-prot-rest alt-prot-rest)
-                                               (and prefer-extension-for-initial-codon-alt?
-                                                    (not= (first ref-prot-seq) (first alt-prot-seq*))))
+              (= (+ base-ppos offset) 1) (if (or (= ref-prot-rest alt-prot-rest)
+                                                 (and prefer-extension-for-initial-codon-alt?
+                                                      (not= (first ref-prot-seq) (first alt-prot-seq*))))
                                            :extension
-
-                                           :else
                                            :frame-shift)
               (and (pos? npref) (= (first palt-only) \*)) (if (ter-site-same-pos? ref-prot-seq alt-prot-seq*)
                                                             :no-effect

--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -279,39 +279,38 @@
       75  110 50)))
 
 (deftest in-frame?-test
-  (let [in-frame? (fn [pos ref alt strand] (#'prot/in-frame? pos ref alt {:cds-start 101
-                                                                          :cds-end 300
-                                                                          :strand strand}))]
+  (let [in-frame? (fn [pos ref alt] (#'prot/in-frame? pos ref alt {:cds-start 101
+                                                                   :cds-end 300}))]
     (testing "within cds"
-      (are [pred pos ref alt strand] (pred (in-frame? pos ref alt strand))
-        true? 200 "A" "T" :forward
-        true? 200 "AGGC" "A" :forward
-        true? 200 "A" "ATCG" :forward
-        true? 200 "AGT" "ACCCTG" :forward
-        true? 150 "T" "A" :reverse
-        true? 150 "GCTC" "G" :reverse
-        true? 150 "T" "TCCG" :reverse
-        true? 150 "TGG" "TCCAAC" :reverse
-        false? 200 "AGG" "A" :forward
-        false? 200 "A" "ATC" :forward
-        false? 200 "AGT" "ACCCT" :forward
-        false? 150 "GCT" "G" :reverse
-        false? 150 "T" "TCC" :reverse
-        false? 150 "TGG" "TCCAA" :reverse))
+      (are [pred pos ref alt] (pred (in-frame? pos ref alt))
+        true? 200 "A" "T"
+        true? 200 "AGGC" "A"
+        true? 200 "A" "ATCG"
+        true? 200 "AGT" "ACCCTG"
+        true? 150 "T" "A"
+        true? 150 "GCTC" "G"
+        true? 150 "T" "TCCG"
+        true? 150 "TGG" "TCCAAC"
+        false? 200 "AGG" "A"
+        false? 200 "A" "ATC"
+        false? 200 "AGT" "ACCCT"
+        false? 150 "GCT" "G"
+        false? 150 "T" "TCC"
+        false? 150 "TGG" "TCCAA"))
     (testing "over ter site"
-      (are [pred pos ref alt strand] (pred (in-frame? pos ref alt strand))
-        true? 294 "CAGTTGAAG" "C" :forward
-        true? 294 "CAGTTGAAG" "CGTC" :forward
-        true? 296 "GTTGAAG" "GCCAA" :forward
-        false? 295 "AGTTGAAG" "A" :forward
-        false? 295 "AGTTGAAG" "ACTC" :forward
-        false? 294 "CAGTTGAAG" "CGT" :forward
-        true? 99 "GTTTACGA" "G" :reverse
-        true? 99 "GTTTACGA" "GCCT" :reverse
-        true? 99 "GTTTACGAC" "GA" :reverse
-        false? 99 "GTTTACG" "G" :reverse
-        false? 96 "CAAGTTTACG" "C" :reverse
-        false? 99 "GTTTACGA" "GAT" :reverse))))
+      (are [pred pos ref alt] (pred (in-frame? pos ref alt))
+        true? 294 "CAGTTGAAG" "C"
+        true? 294 "CAGTTGAAG" "CGTC"
+        true? 296 "GTTGAAG" "GCCAA"
+        false? 295 "AGTTGAAG" "A"
+        false? 295 "AGTTGAAG" "ACTC"
+        false? 294 "CAGTTGAAG" "CGT"
+        true? 99 "GTTTACGA" "G"
+        true? 99 "GTTTACGA" "GCCT"
+        true? 99 "GTTTACGAC" "GA"
+        false? 99 "GTTTACG" "G"
+        false? 96 "CAAGTTTACG" "C"
+        false? 99 "GTTTACGA" "GAT"))))
 
 (deftest apply-offset-test
   (testing "ref not include exon terminal"

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -223,13 +223,17 @@
         "chr13" 24421115 "TGACTTAGCC" "T" '("p.G1724K") ; not actual example (-, del includes termination codon)
         "chrX" 15823233 "ATCCAAATAAAC" "A" '("p.S481*") ; not actual example (+, del includes termination codon)
 
-        ;; deletion
+        ;; Deletion
         "chr1" 240092288 "AGTC" "A" '("p.S61del") ; cf. rs772088733 (+)
         "chr7" 55174771 "AGGAATTAAGAGAAGC" "A" '("p.E746_A750del") ; cf. rs121913421 (+)
         "chr1" 247815239 "AAGG" "A" '("p.S163del") ; cf. rs35979231 (-)
         "chr2" 29223408 "AAGCAGT" "A" '("p.Y1096_C1097del") ; cf. rs776101205 (-)
         "chr11" 108259071 "GT" "G" '("p.L822*") ; https://github.com/chrovis/varity/issues/49
         "chr17" 7676206 "TGAACCATTGTTCAATATCGTCCGGGGACAGCATCAAATCATCCATTGCTTGGGACGGCAAGGGG" "T" '("p.P34Lfs*68" "p.?") ; https://mutalyzer.nl/normalizer/NC_000017.11:g.7676209_7676272del
+
+        ;; deletion includes initiation codon
+        "chr13" 24503770 "TCACCATC" "T" '("p.V2_M3del") ; not actual example(-)
+        "chr13" 24503770 "TCACCA" "T" '("p.?") ; not actual example(-)
 
         ;; Duplication
         "chr2" 26254257 "G" "GACT" '("p.T2dup") ; cf. rs3839049 (+)
@@ -379,7 +383,10 @@
         "chr13" 24421115 "TGACTTAGCCT" "T" {:three-prime-rule {:restrict-cds true}} '("p.G1724Nfs*6") ;; not actual example (-)
         "chr13" 24421115 "TGACTTAGCCT" "T" {:three-prime-rule {:restrict-cds false}} '("p.G1724delinsNETEF") ;; not actual example (-)
         "chr3" 53495165 "GGAT" "G" {:three-prime-rule {:restrict-cds true} :prefer-insertion? true :prefer-deletion? true} '("p.?") ;; not actual example (+)
-        "chr3" 53495165 "GGAT" "G" {:three-prime-rule {:restrict-cds false} :prefer-insertion? true :prefer-deletion? true} '("p.M7del")))) ;; not actual example (+)
+        "chr3" 53495165 "GGAT" "G" {:three-prime-rule {:restrict-cds false} :prefer-insertion? true :prefer-deletion? true} '("p.M7del") ;; not actual example (+)
+        "chr13" 24503771 "CACCATCC" "C" {:three-prime-rule {:restrict-cds true} :prefer-insertion? true :prefer-deletion? true} '() ; not actual example(-), affects exon/intron boundary
+        "chr13" 24503771 "CACCATCC" "C" {:three-prime-rule {:restrict-cds false} :prefer-insertion? true :prefer-deletion? true} '("p.V2_M3del") ; not actual example(-)
+        )))
 
   (cavia-testing "throws Exception if inputs are illegal"
     (let [rgidx (rg/index (rg/load-ref-genes test-ref-gene-file))]


### PR DESCRIPTION
I fixed ref and alt-cds-exon-seq in seq-info and refactored in-frame determine fn.
This only affects `ini-site-affected` in `->protein-variant`.