### PR TITLE
Add resettable LRU memoization to `overlap-exon-intron-boundary?`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :min-lein-version "2.7.0"
   :dependencies [[org.clojure/clojure "1.12.0" :scope "provided"]
+                 [org.clojure/core.memoize "1.1.266"]
                  [org.clojure/tools.logging "1.2.4"]
                  [clj-hgvs "0.5.1"]
                  [cljam "0.8.3"]


### PR DESCRIPTION
Closes chrovis/varity#131

This PR will address the above unbounded memory growth issue.
* Instead of `memoize`, `clojure.core.memoize/lru` is used to limit cache size
* Added `reset-overlap-exon-intron-boundary?!` that enables users to change memoization strategy
* Changed `overlap-exon-intron-boundary?`to public, since it seems more natural when having a resettable behavior
* Passed all unit tests and confirmed stable memory usage by `tsudatatsuya/varity-leak` and chrovis-reference validation