### PR TITLE
Fix coding-dna vcf-to-hgvs substitution

### DIFF
--- a/src/varity/vcf_to_hgvs/coding_dna.clj
+++ b/src/varity/vcf_to_hgvs/coding_dna.clj
@@ -101,7 +101,11 @@
 (defn- dna-substitution
   [rg pos ref alt]
   (let [{:keys [strand]} rg
-        type (if (= ref alt) "=" ">")]
+        [ref alt offset _] (if (= 1 (count ref) (count alt))
+                             [ref alt 0 0]
+                             (diff-bases ref alt))
+        type (if (= ref alt) "=" ">")
+        pos (+ pos offset)]
     (mut/dna-substitution (rg/cds-coord pos rg)
                           (cond-> ref (= strand :reverse) util-seq/revcomp)
                           type

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -108,6 +108,7 @@
                                   "NM_001276696:c.98C="
                                   "NM_001276760:c.98C="
                                   "NM_001276761:c.98C=") ; cf. rs1042522
+        "chr1" 115739063 "TA" "AA" '("NM_001232:c.421-728A>T") ; not actual example at intergenic region
 
         ;; Deletion
         "chr1" 963222 "GCG" "G" '("NM_015658:c.-3983_-3982delGC"


### PR DESCRIPTION
I found coding-dna alteration format is not correct(`c.421-728TA>TT`) in the following case.
```
ref: TA
alt: AA
ref-only: T
alt-only: A
```
So I fixed vcf-to-hgvs dna-substitution process.