### PR TITLE
Fix protein ref alt for deletion starts from 5-prime end of exon

### DIFF
--- a/test/varity/vcf_to_hgvs/protein_test.clj
+++ b/test/varity/vcf_to_hgvs/protein_test.clj
@@ -334,6 +334,17 @@
         false? 96 "CAAGTTTACG" "C"
         false? 99 "GTTTACGA" "GAT"))))
 
+(deftest deletion-from-five-prime-end-and-first-base?
+  (let [rg {:exon-ranges [[11 20] [31 50] [61 80]] :tx-start 11 :tx-end 80}]
+    (testing "forward strand"
+      (are [pred rg* pos ref alt] (pred (#'prot/deletion-from-five-prime-end-and-first-base? (merge rg rg*) pos ref alt))
+        true? {:strand :forward :cds-start 18 :cds-end 64} 30 "GGTA" "G"
+        false? {:strand :forward :cds-start 17 :cds-end 63} 30 "GGTA" "G"))
+    (testing "reverse strand"
+      (are [pred rg* pos ref alt] (pred (#'prot/deletion-from-five-prime-end-and-first-base? (merge rg rg*) pos ref alt))
+        true? {:strand :reverse :cds-start 17 :cds-end 63} 47 "CGTG" "C"
+        false? {:strand :reverse :cds-start 18 :cds-end 64} 47 "CGTG" "C"))))
+
 (deftest apply-offset-test
   (testing "ref not include exon terminal"
     (let [ref "GCTGACC"

--- a/test/varity/vcf_to_hgvs_test.clj
+++ b/test/varity/vcf_to_hgvs_test.clj
@@ -401,6 +401,10 @@
 
         ;; unknown because variant includes termination site and alternative termination site is not found
         "chr17" 81537074 "GTACTGAGGC" "G" '("p.?") ; not actual example(+)
+
+        ;; in-frame deletion starts from 5' prime end of exon and first base of codon
+        "chr4" 54727415 "GAAACCCATGTATGAAGTACAGTGGAAG" "G" '("p.K550_K558del" "p.K546_K554del") ;; not actual example (+)
+        "chr17" 7674284 "AGCCAAC" "A" '("p.V93_G94del" "p.V66_G67del" "p.V225_G226del" "p.V186_G187del")  ;; not actual example (-)
         )))
 
   (cavia-testing "options"


### PR DESCRIPTION
I fixed protein ref, alt and add deletion condition for in-frame deletion variants that start with 5' end of exon and 1st base of codon.