### PR TITLE
Fix/off by one in search chains

### DIFF
--- a/src/varity/chain.clj
+++ b/src/varity/chain.clj
@@ -78,12 +78,13 @@
          curr-q-start (inc (:q-start header))]
     (if-not d
       (persistent! results)
-      (recur (->> (assoc d :t-start curr-t-start
+      (recur (->> (assoc d
+                         :t-start curr-t-start
                          :q-start curr-q-start
-                         :t-end (+ curr-t-start (:size d))
-                         :q-end (+ curr-q-start (:size d))
+                         :t-end (dec (+ curr-t-start (:size d)))
+                         :q-end (dec (+ curr-q-start (:size d)))
                          :start curr-t-start
-                         :end (+ curr-t-start (:size d)))
+                         :end (dec (+ curr-t-start (:size d))))
                   (conj! results))
              (first r)
              (next r)
@@ -114,9 +115,9 @@
 (defn- in-block?
   [pos {:keys [data header] :as chain}]
   (when (<= (inc (:t-start header)) pos (:t-end header))
-    (when-let [m (first (intervals/find-overlap-intervals data nil pos (inc pos)))]
-      (when (<= (:t-start m) pos (dec (+ (:t-start m) (:size m))))
-        (assoc chain :in-block m)))))
+    (when-let [m (first (intervals/find-overlap-intervals data nil pos pos))]
+        (assoc chain :in-block m))))
+
 
 (def ^:private normalize-chr (memoize normalize-chromosome-key))
 
@@ -138,4 +139,4 @@
 (defn search-overlap-blocks
   "Calculates a list of blocks that overlap the given interval."
   [start end blocks-idx]
-  (intervals/find-overlap-intervals blocks-idx nil (inc start) end))
+  (intervals/find-overlap-intervals blocks-idx nil start end))

--- a/test/varity/chain_test.clj
+++ b/test/varity/chain_test.clj
@@ -22,6 +22,44 @@
    "chr2" [{:header {:t-name "chr2", :t-start 0, :t-end 300 :score 1}}]
    "chr3" [{:header {:t-name "chr2", :t-start 0, :t-end 300 :score 1}}]})
 
+(deftest search-chains-test
+  (let [chain [{:header
+                {:t-name "chr1" :q-name "chr1"
+                 :t-start 0 :q-start 0
+                 :t-end 26 :q-end 18
+                 :tsize 26 :q-size 18}
+                :data
+                [{:size 10 :dt 2 :dq 0}
+                 {:size 1 :dt 0 :dq 2}
+                 {:size 1 :dt 4 :dq 0}
+                 {:size 1 :dt 4 :dq 0}
+                 {:size 3}]}]
+        chain-idx (chain/index chain)]
+    (are [pos ans] (= (-> (chain/search-chains "chr1" pos chain-idx)
+                          first
+                          :in-block
+                          (select-keys [:q-start :t-start])
+                          not-empty)
+                      ans)
+      9 {:t-start 1 :q-start 1}
+      10 {:t-start 1 :q-start 1}
+      11 nil
+      12 nil
+      13 {:t-start 13 :q-start 11} ;;gap=+2
+      14 {:t-start 14 :q-start 14} ;;gap=+2-2
+      15  nil
+      16  nil
+      17  nil
+      18  nil
+      19 {:t-start 19 :q-start 15} ;;gap=+2-2+4
+      20  nil
+      21  nil
+      22  nil
+      23  nil
+      24  {:t-start 24 :q-start 16} ;;gap-+2-2+4+4
+      25  {:t-start 24 :q-start 16}
+      26  {:t-start 24 :q-start 16})))
+
 (deftest search-overlap-blocks-test
   (are [start end ans] (= (map #(select-keys % [:t-start :t-end])
                                (chain/search-overlap-blocks start end sample-indexed-block))

--- a/test/varity/chain_test.clj
+++ b/test/varity/chain_test.clj
@@ -68,7 +68,7 @@
     15 17 [{:t-start 14, :t-end 16}]
     6 7 [{:t-start 6, :t-end 10}]
     4 4 [{:t-start 2, :t-end 5}]
-    5 5 []
+    5 5 [{:t-start 2, :t-end 5}]
     6 6 [{:t-start 6, :t-end 10}]
     1 1 []
     30 31 []))


### PR DESCRIPTION
This PR fixes an issue where the search range of `in-block?` was off by one. Similar to [search-overlap-block](https://github.com/chrovis/varity/blob/4ac78377f8df48830cf5fd315e242069178efac2/src/varity/chain.clj#L141C27-L141C36), it needs to search one position further back.