### PR TITLE
Index chain headers

### DIFF
--- a/src/varity/chain.clj
+++ b/src/varity/chain.clj
@@ -105,19 +105,16 @@
 (defn index
   "Creates chain index for search."
   [chains]
-  (->> (group-by (comp :t-name :header) chains)
-       (into {} (map
-                 (fn [[chr xs]]
-                   [(normalize-chromosome-key chr)
-                    (mapv index-chain xs)])))))
+  (intervals/index-intervals
+   (map (fn [{{:keys [t-name t-start t-end]} :header :as chain}]
+          (assoc (index-chain chain)
+                 :chr (normalize-chromosome-key t-name)
+                 ;; zero-based half-open => one-based closed
+                 :start (inc t-start)
+                 :end t-end)) chains)
+   {:structure :nclist}))
 
 ;;; Search
-(defn- in-block?
-  [pos {:keys [data header] :as chain}]
-  (when (<= (inc (:t-start header)) pos (:t-end header))
-    (when-let [m (first (intervals/find-overlap-intervals data nil pos pos))]
-        (assoc chain :in-block m))))
-
 
 (def ^:private normalize-chr (memoize normalize-chromosome-key))
 
@@ -125,13 +122,19 @@
   "Searches chain entries with chr and pos using the index, returning the
   results as a sequence. See also varity.chain/index."
   [chr pos chain-idx]
-  (->> (chain-idx (normalize-chr chr))
-       (keep (partial in-block? pos))))
+  (->> (intervals/find-overlap-intervals
+        chain-idx (normalize-chr chr) pos pos)
+       (keep
+        (fn [{:keys [data] :as chain}]
+          (when-let [m (first (intervals/find-overlap-intervals
+                               data nil pos pos))]
+            (assoc chain :in-block m))))))
 
 (defn search-containing-chains
   "Calculates a list of chains that contain the given interval."
   [chr start end chain-idx]
-  (->> (chain-idx (normalize-chr chr))
+  (->> (intervals/find-overlap-intervals
+        chain-idx (normalize-chr chr) start end)
        (filter #(and (<= (get-in % [:header :t-start]) start)
                      (<= end (get-in % [:header :t-end]))))
        (sort-by (comp :score :header) >)))

--- a/test/varity/chain_test.clj
+++ b/test/varity/chain_test.clj
@@ -1,5 +1,5 @@
 (ns varity.chain-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [cljam.util.intervals :as intervals]
             [varity.chain :as chain]))
 
@@ -14,51 +14,77 @@
          {:t-start 18 :t-end 20}])
    {:structure :nclist}))
 
-(def ^:private ^:const sample-indexed-chain
-  {"chr1" [{:header {:t-name "chr1", :t-start 0, :t-end 100 :score 1}}
-           {:header {:t-name "chr1", :t-start 100, :t-end 200 :score 2}}
-           {:header {:t-name "chr1", :t-start 200, :t-end 300 :score 3}}
-           {:header {:t-name "chr1", :t-start 250, :t-end 350 :score 4}}]
-   "chr2" [{:header {:t-name "chr2", :t-start 0, :t-end 300 :score 1}}]
-   "chr3" [{:header {:t-name "chr2", :t-start 0, :t-end 300 :score 1}}]})
+(def ^:private sample-indexed-chain
+  (chain/index
+   [{:header {:t-name "chr1", :t-start 0, :t-end 100, :score 1, :id 1,
+              :q-name "1", :q-start 0, :q-end 100}, :data [{:size 100}]}
+    {:header {:t-name "chr1", :t-start 100, :t-end 200, :score 2, :id 2,
+              :q-name "1", :q-start 100, :q-end 200}, :data [{:size 100}]}
+    {:header {:t-name "chr1", :t-start 200, :t-end 300, :score 3, :id 3,
+              :q-name "1", :q-start 200, :q-end 300}, :data [{:size 100}]}
+    {:header {:t-name "chr1", :t-start 250, :t-end 350, :score 4, :id 4,
+              :q-name "1", :q-start 250, :q-end 350}, :data [{:size 100}]}
+    {:header {:t-name "chr2", :t-start 0, :t-end 300, :score 1, :id 5,
+              :q-name "2", :q-start 0, :q-end 300}, :data [{:size 300}]}
+    {:header {:t-name "chr3", :t-start 0, :t-end 300, :score 1, :id 6,
+              :q-name "3", :q-start 0, :q-end 300}, :data [{:size 300}]}]))
 
 (deftest search-chains-test
-  (let [chain [{:header
-                {:t-name "chr1" :q-name "chr1"
-                 :t-start 0 :q-start 0
-                 :t-end 26 :q-end 18
-                 :tsize 26 :q-size 18}
-                :data
-                [{:size 10 :dt 2 :dq 0}
-                 {:size 1 :dt 0 :dq 2}
-                 {:size 1 :dt 4 :dq 0}
-                 {:size 1 :dt 4 :dq 0}
-                 {:size 3}]}]
-        chain-idx (chain/index chain)]
-    (are [pos ans] (= (-> (chain/search-chains "chr1" pos chain-idx)
-                          first
-                          :in-block
-                          (select-keys [:q-start :t-start])
-                          not-empty)
-                      ans)
-      9 {:t-start 1 :q-start 1}
-      10 {:t-start 1 :q-start 1}
-      11 nil
-      12 nil
-      13 {:t-start 13 :q-start 11} ;;gap=+2
-      14 {:t-start 14 :q-start 14} ;;gap=+2-2
-      15  nil
-      16  nil
-      17  nil
-      18  nil
-      19 {:t-start 19 :q-start 15} ;;gap=+2-2+4
-      20  nil
-      21  nil
-      22  nil
-      23  nil
-      24  {:t-start 24 :q-start 16} ;;gap-+2-2+4+4
-      25  {:t-start 24 :q-start 16}
-      26  {:t-start 24 :q-start 16})))
+  (testing "single chain"
+    (let [chain [{:header
+                  {:t-name "chr1" :q-name "chr1"
+                   :t-start 0 :q-start 0
+                   :t-end 26 :q-end 18
+                   :tsize 26 :q-size 18}
+                  :data
+                  [{:size 10 :dt 2 :dq 0}
+                   {:size 1 :dt 0 :dq 2}
+                   {:size 1 :dt 4 :dq 0}
+                   {:size 1 :dt 4 :dq 0}
+                   {:size 3}]}]
+          chain-idx (chain/index chain)]
+      (are [pos ans] (= (-> (chain/search-chains "chr1" pos chain-idx)
+                            first
+                            :in-block
+                            (select-keys [:q-start :t-start])
+                            not-empty)
+                        ans)
+        9 {:t-start 1 :q-start 1}
+        10 {:t-start 1 :q-start 1}
+        11 nil
+        12 nil
+        13 {:t-start 13 :q-start 11} ;;gap=+2
+        14 {:t-start 14 :q-start 14} ;;gap=+2-2
+        15  nil
+        16  nil
+        17  nil
+        18  nil
+        19 {:t-start 19 :q-start 15} ;;gap=+2-2+4
+        20  nil
+        21  nil
+        22  nil
+        23  nil
+        24  {:t-start 24 :q-start 16} ;;gap-+2-2+4+4
+        25  {:t-start 24 :q-start 16}
+        26  {:t-start 24 :q-start 16})))
+  (testing "multiple chains"
+    (letfn [(overlapping-ids [chr pos]
+              (->> sample-indexed-chain
+                   (chain/search-chains chr pos)
+                   (map (comp :id :header))
+                   sort))]
+      (is (= (overlapping-ids "chr1"   1) [1]))
+      (is (= (overlapping-ids "chr1" 100) [1]))
+      (is (= (overlapping-ids "chr1" 101) [2]))
+      (is (= (overlapping-ids "chr1" 101) [2]))
+      (is (= (overlapping-ids "chr1" 200) [2]))
+      (is (= (overlapping-ids "chr1" 201) [3]))
+      (is (= (overlapping-ids "chr1" 250) [3]))
+      (is (= (overlapping-ids "chr1" 251) [3 4]))
+      (is (= (overlapping-ids "chr1" 300) [3 4]))
+      (is (= (overlapping-ids "chr1" 301) [4]))
+      (is (= (overlapping-ids "chr1" 350) [4]))
+      (is (= (overlapping-ids "chr1" 351) [])))))
 
 (deftest search-overlap-blocks-test
   (are [start end ans] (= (map #(select-keys % [:t-start :t-end])
@@ -74,12 +100,11 @@
     30 31 []))
 
 (deftest search-containing-chains-test
-  (is (= (chain/search-containing-chains "chr1" 10 20 sample-indexed-chain)
-         [{:header {:t-name "chr1", :t-start 0, :t-end 100 :score 1}}]))
-  (is (= (chain/search-containing-chains "chr1" 260 270 sample-indexed-chain)
-         [{:header {:t-name "chr1", :t-start 250, :t-end 350 :score 4}}
-          {:header {:t-name "chr1", :t-start 200, :t-end 300 :score 3}}]))
-  (is (= (chain/search-containing-chains "chr1" 10 120 sample-indexed-chain)
-         []))
-  (is (= (chain/search-containing-chains "chr2" 10 20 sample-indexed-chain)
-         [{:header {:t-name "chr2", :t-start 0, :t-end 300 :score 1}}])))
+  (letfn [(containing-ids [chr start end]
+            (->> sample-indexed-chain
+                 (chain/search-containing-chains chr start end)
+                 (map (comp :id :header))))]
+    (is (= (containing-ids "chr1"  10  20) [1]))
+    (is (= (containing-ids "chr1" 260 270) [4 3]))
+    (is (= (containing-ids "chr1"  10 120) []))
+    (is (= (containing-ids "chr2"  10  20) [5]))))


### PR DESCRIPTION
This PR adds a new index over the `:header`s of the entire chain dataset.

Previously, `varity.chain/index` created indexes for the `:data` lines within each individual chain, but finding the overlapping chains still required a linear scan.
This was not a problem when the total number of chains was small. However, `vairty.lift/convert-coord`/`varity.vcf-lift/liftover-variants` could be extremely slow when using chain files that represent complex mappings. By indexing `:t-start` and `:t-end` fields in the chain headers, liftover can now be performed efficiently even with such chain files.

I confirmed that this change does not degrade performance for the existing small chain files.

##### master

```
large-vcf-lift-bench (large_vcf_lift_bench.clj:14)

  time: 989.635348 ns, sd: 0.000004 ns
```

##### branch

```
large-vcf-lift-bench (large_vcf_lift_bench.clj:14)

  time: 978.089457 ns, sd: 0.000004 ns
```

> [!NOTE]
> As documented in the [UCSC chain format specification](https://genome.ucsc.edu/goldenpath/help/chain.html), chain files use 0-based, half-open intervals, whereas the `cljam.util.intervals` requires 1-based, closed intervals. The coordinates are converted when they are added to the index.